### PR TITLE
Update fome_console.xml to use open-source JAVA distribution

### DIFF
--- a/misc/console_launcher/fome_console.xml
+++ b/misc/console_launcher/fome_console.xml
@@ -8,7 +8,7 @@
   <cmdLine></cmdLine>
   <chdir>.</chdir>
   <priority>normal</priority>
-  <downloadUrl>http://java.com/download</downloadUrl>
+  <downloadUrl>https://adoptium.net/download/</downloadUrl>
   <supportUrl></supportUrl>
   <stayAlive>false</stayAlive>
   <restartOnCrash>false</restartOnCrash>


### PR DESCRIPTION
I would strongly advise to switch to an open-source distribution due to ORACLE changing their license to be non-free some time ago. Recommended is a version with long-time support (LTS)