### PR TITLE
Fix compiler error in simulator

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -352,7 +352,7 @@ void unlockEcu(int password);
 // These externs aren't needed for unit tests - everything is injected instead
 #if !EFI_UNIT_TEST
 extern Engine ___engine;
-static Engine * const engine = &___engine;
+static Engine * engine = &___engine;
 #else // EFI_UNIT_TEST
 extern Engine *engine;
 #endif // EFI_UNIT_TEST


### PR DESCRIPTION
> ../firmware/console/binary_log/log_fields_generated.h:351:1: error: the value of ‘engine’ is not usable in a constant expression