### PR TITLE
separate ign bench parameters

### DIFF
--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -76,6 +76,10 @@ void setDefaultBaseEngine() {
 	engineConfiguration->benchTestOffTime = 500;
 	engineConfiguration->benchTestCount = 3;
 
+	engineConfiguration->ignTestOnTime = 3;
+	engineConfiguration->ignTestOffTime = 500;
+	engineConfiguration->ignTestCount = 3;
+
 	// Fans
 	engineConfiguration->fanOnTemperature = 95;
 	engineConfiguration->fanOffTemperature = 91;

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -437,8 +437,8 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 
 	case TS_IGNITION_CATEGORY:
 		if (!running) {
-			doRunSparkBench(index, engineConfiguration->benchTestOnTime,
-				engineConfiguration->benchTestOffTime, engineConfiguration->benchTestCount);
+			doRunSparkBench(index, engineConfiguration->ignTestOnTime,
+				engineConfiguration->ignTestOffTime, engineConfiguration->ignTestCount);
 		}
 		break;
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1089,6 +1089,7 @@ int16_t tps2Max;;"ADC", 1, 0, 0, 1023, 0
 	uint8_t coastingFuelCutVssLow;Below this speed, disable DFCO. Use this to prevent jerkiness from fuel enable/disable in low gears.;"kph", 1, 0, 0, 255, 0
 	uint8_t coastingFuelCutVssHigh;Above this speed, allow DFCO. Use this to prevent jerkiness from fuel enable/disable in low gears.;"kph", 1, 0, 0, 255, 0
 	uint8_t autoscale noFuelTrimAfterDfcoTime;Pause closed loop fueling after deceleration fuel cut occurs. Set this to a little longer than however long is required for normal fueling behavior to resume after fuel cut.;"sec", 0.1, 0, 0, 10, 1
+	uint8_t autoscale ignTestOnTime;Duration of each test pulse;"ms", 0.1, 0, 0, 10, 1
 	float tpsAccelEnrichmentThreshold;Maximum change delta of TPS percentage over the 'length'. Actual TPS change has to be above this value in order for TPS/TPS acceleration to kick in.;"roc", 1, 0, 0, 200, 1
 
     brain_input_pin_e[2 iterate] auxSpeedSensorInputPin;
@@ -1471,7 +1472,10 @@ pin_input_mode_e[LUA_DIGITAL_INPUT_COUNT iterate] luaDigitalInputPinModes;
 
 	uint8_t autoscale rpmHardLimitHyst;If the hard limit is 7200rpm and hysteresis is 200rpm, then when the ECU sees 7200rpm, fuel/ign will cut, and stay cut until 7000rpm (7200-200) is reached;"RPM", 10, 0, 0, 2500, 0
 
-uint8_t[95] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
+	uint8_t ignTestCount;How many test bench pulses do you want;"", 1, 0, 0, 50, 0
+	uint8_t autoscale ignTestOffTime;Time between bench test pulses;"ms", 5, 0, 0, 2000, 0
+
+uint8_t[93] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -4123,9 +4123,9 @@ dialog = tcuControls, "Transmission Settings"
 		commandButton = "Spark #12", cmd_test_spk12, { cylindersCount >= 12 }
 
 	dialog = ignTest_c, ""
-		field = "Iterations", benchTestCount
-		field = "ON time", benchTestOnTime
-		field = "OFF time", benchTestOffTime
+		field = "Iterations", ignTestCount
+		field = "ON time", ignTestOnTime
+		field = "OFF time", ignTestOffTime
 		commandButton = "Abort test", cmd_test_cancel
 		gauge = testBenchIterGauge
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1249,6 +1249,7 @@ gaugeCategory = Trigger
 
 gaugeCategory = Test Bench
 	testBenchIterGauge = testBenchIter, "Test Bench Iterations", "count", 0, {benchTestCount}, 0, 0, {benchTestCount}, {benchTestCount}, 0, 0
+	testIgnIterGauge = testBenchIter, "Ignition Test Iterations", "count", 0, {ignTestCount}, 0, 0, {ignTestCount}, {ignTestCount}, 0, 0
 
 gaugeCategory = LUA
 	luaInvocationCounterGauge = luaInvocationCounter,"luaInvocationCounter", "count", 0.0,0.0, 0.0,0.0, 0.0,0.0, 0,0
@@ -4127,7 +4128,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "ON time", ignTestOnTime
 		field = "OFF time", ignTestOffTime
 		commandButton = "Abort test", cmd_test_cancel
-		gauge = testBenchIterGauge
+		gauge = testIgnIterGauge
 
 	dialog = ignTest, "", xAxis
 		panel = ignTest_l


### PR DESCRIPTION
Separate on/off/count parameters for ignition, as it's easier to kill that hardware with bad settings.

related #219 