### PR TITLE
remove warning message from configuration

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -268,9 +268,6 @@ void Engine::preCalculate() {
 	// we take 2 bytes of crc32, no idea if it's right to call it crc16 or not
 	// we have a hack here - we rely on the fact that engineMake is the first of three relevant fields
 	engine->outputChannels.engineMakeCodeNameCrc16 = crc32(engineConfiguration->engineMake, 3 * VEHICLE_INFO_SIZE);
-
-	// we need and can empty warning message for CRC purposes
-	memset(config->warning_message, 0, sizeof(error_message_t));
 	engine->outputChannels.tuneCrc16 = crc32(config, sizeof(persistent_config_s));
 #endif /* EFI_TUNER_STUDIO */
 }

--- a/firmware/controllers/algo/rusefi_types.h
+++ b/firmware/controllers/algo/rusefi_types.h
@@ -107,8 +107,6 @@ typedef void (*Void)(void);
 
 using lua_script_t = char[LUA_SCRIPT_SIZE];
 
-using error_message_t = char[ERROR_BUFFER_SIZE];
-
 using vehicle_info_t = char[VEHICLE_INFO_SIZE];
 
 using vin_number_t = char[VIN_NUMBER_SIZE];

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -144,12 +144,6 @@ bool warning(ObdCode code, const char *fmt, ...) {
 	chvsnprintf(warningBuffer, sizeof(warningBuffer), fmt, ap);
 	va_end(ap);
 
-	if (engineConfiguration->showHumanReadableWarning) {
-#if EFI_TUNER_STUDIO
-  memcpy(persistentState.persistentConfiguration.warning_message, warningBuffer, sizeof(warningBuffer));
-#endif /* EFI_TUNER_STUDIO */
-	}
-
 	efiPrintf("WARNING: %s", warningBuffer);
 #else
 	// todo: we need access to 'engine' here so that we can migrate to real 'engine->engineState.warnings'

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -318,7 +318,6 @@ void readFromFlash() {
 
 	// we can only change the state after the CRC check
 	engineConfiguration->byFirmwareVersion = getRusEfiVersion();
-	memset(persistentState.persistentConfiguration.warning_message , 0, ERROR_BUFFER_SIZE);
 	validateConfiguration();
 }
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -92,7 +92,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 20012
+#define FLASH_DATA_VERSION 20013
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -830,8 +830,6 @@ sensor_chart_e sensorChartMode;rusEFI console Sensor Sniffer mode;
 	custom vehicle_info_t @@VEHICLE_INFO_SIZE@@ string, ASCII, @OFFSET@, @@VEHICLE_INFO_SIZE@@
 	custom gppwm_note_t @@GPPWM_NOTE_SIZE@@ string, ASCII, @OFFSET@, @@GPPWM_NOTE_SIZE@@
 
-	custom error_message_t @@ERROR_BUFFER_SIZE@@ string, ASCII, @OFFSET@, @@ERROR_BUFFER_SIZE@@
-
 	bit clutchUpPinInverted
 	bit clutchDownPinInverted
 	bit useHbridgesToDriveIdleStepper;If enabled we use two H-bridges to drive stepper idle air valve
@@ -839,7 +837,7 @@ sensor_chart_e sensorChartMode;rusEFI console Sensor Sniffer mode;
 	bit enableLaunchRetard
 	bit enableCanVss;Read VSS from OEM CAN bus according to selected CAN vehicle configuration.
 	bit enableInnovateLC2
-	bit showHumanReadableWarning
+	bit unused808b7
 	bit stftIgnoreErrorMagnitude;If enabled, adjust at a constant rate instead of a rate proportional to the current lambda error. This mode may be easier to tune, and more tolerant of sensor noise.
 	bit enableSoftwareKnock
 	bit verboseVVTDecoding;Verbose info in console below engineSnifferRpmThreshold\nenable vvt_details
@@ -1534,8 +1532,6 @@ uint16_t[CRANKING_ADVANCE_CURVE_SIZE] crankingAdvanceBins;Optional timing advanc
 int16_t[CRANKING_ADVANCE_CURVE_SIZE] autoscale crankingAdvance;Optional timing advance table for Cranking (see useSeparateAdvanceForCranking);"deg", 0.01, 0, -20, 90, 2
 uint8_t[CLT_CURVE_SIZE] autoscale iacCoastingRpmBins;RPM-based idle position for coasting;"RPM", 100, 0, 0, 25000, 0
 uint8_t[CLT_CURVE_SIZE] autoscale iacCoasting;    RPM-based idle position for coasting;"%", 0.5, 0, 0, 100, 1
-
-error_message_t warning_message;
 
 float[AFTERSTART_HOLD_CURVE_SIZE] afterstartCoolantBins;;"C", 1, 0, -100, 250, 0
 float[AFTERSTART_HOLD_CURVE_SIZE] afterstartHoldTime;;"Seconds", 1, 0, 0, 100, 1

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -294,8 +294,6 @@ enable2ndByteCanID = false
 
 	requiresPowerCycle = knockBandCustom
 
-	readOnly = warning_message
-
 	defaultValue = gearCountArray, -1 0 1 2 3 4 5 6 7 8
 	readOnly = gearCountArray
 	defaultValue = solenoidCountArray, 1 2 3 4 5 6 7 8
@@ -4366,8 +4364,6 @@ dialog = tcuControls, "Transmission Settings"
 		field = "#System hacks"
 		field = "Global fuel correction",				globalFuelCorrection
 		field = "MAP Averaging Logic @",				mapAveragingSchedulingAtIndex
-		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
-		field = "Warning Message",							warning_message
 		field = "Ford redundant TPS mode",				useFordRedundantTps
 		field = "Secondary TPS maximum",				tpsSecondaryMaximum, {useFordRedundantTps}
 		field = "Ford redundant PPS mode",				useFordRedundantPps

--- a/java_console/ui/src/main/java/com/rusefi/tools/ConsoleTools.java
+++ b/java_console/ui/src/main/java/com/rusefi/tools/ConsoleTools.java
@@ -117,8 +117,6 @@ public class ConsoleTools {
     }
 
     private static void printCrc(ConfigurationImage image) {
-        for (int i = 0; i < Fields.ERROR_BUFFER_SIZE; i++)
-            image.getContent()[Fields.WARNING_MESSAGE.getOffset() + i] = 0;
         int crc32 = getCrc32(image.getContent());
         int crc16 = crc32 & 0xFFFF;
         System.out.printf("tune_CRC32_hex=0x%x\n", crc32);


### PR DESCRIPTION
Outputs don't belong in the configuration, and are a landmine for TS getting confused.