### PR TITLE
Fixed FOME CAN data bus selection

### DIFF
--- a/firmware/controllers/can/can_dash.cpp
+++ b/firmware/controllers/can/can_dash.cpp
@@ -1293,14 +1293,16 @@ void canDashboardAim(CanCycle cycle) {
 		return;
 	}
 
-	transmitStruct<Aim5f0>(0x5f0, false);
-	transmitStruct<Aim5f1>(0x5f1, false);
-	transmitStruct<Aim5f2>(0x5f2, false);
-	transmitStruct<Aim5f3>(0x5f3, false);
-	transmitStruct<Aim5f4>(0x5f4, false);
-	transmitStruct<Aim5f5>(0x5f5, false);
-	transmitStruct<Aim5f6>(0x5f6, false);
-	transmitStruct<Aim5f7>(0x5f7, false);
+	auto canChannel = engineConfiguration->canBroadcastUseChannelTwo;
+
+	transmitStruct<Aim5f0>(0x5f0, false, canChannel);
+	transmitStruct<Aim5f1>(0x5f1, false, canChannel);
+	transmitStruct<Aim5f2>(0x5f2, false, canChannel);
+	transmitStruct<Aim5f3>(0x5f3, false, canChannel);
+	transmitStruct<Aim5f4>(0x5f4, false, canChannel);
+	transmitStruct<Aim5f5>(0x5f5, false, canChannel);
+	transmitStruct<Aim5f6>(0x5f6, false, canChannel);
+	transmitStruct<Aim5f7>(0x5f7, false, canChannel);
 
 	// there are more, but less important for us
 	// transmitStruct<Aim5f8>(0x5f8, false);

--- a/firmware/controllers/can/can_verbose.cpp
+++ b/firmware/controllers/can/can_verbose.cpp
@@ -216,17 +216,18 @@ static void populateFrame(Odometry& msg) {
 void sendCanVerbose() {
 	auto base = engineConfiguration->verboseCanBaseAddress;
 	auto isExt = engineConfiguration->rusefiVerbose29b;
+	auto canChannel = engineConfiguration->canBroadcastUseChannelTwo;
 
-	transmitStruct<Status>		(base + 0, isExt);
-	transmitStruct<Speeds>		(base + 1, isExt);
-	transmitStruct<PedalAndTps>	(base + CAN_PEDAL_TPS_OFFSET, isExt);
-	transmitStruct<Sensors1>	(base + CAN_SENSOR_1_OFFSET, isExt);
-	transmitStruct<Sensors2>	(base + 4, isExt);
-	transmitStruct<Fueling>		(base + 5, isExt);
-	transmitStruct<Fueling2>	(base + 6, isExt);
-	transmitStruct<Fueling3>	(base + 7, isExt);
-	transmitStruct<Cams>		(base + 8, isExt);
-	transmitStruct<Odometry>	(base + 9, isExt);
+	transmitStruct<Status>		(base + 0, isExt, canChannel);
+	transmitStruct<Speeds>		(base + 1, isExt, canChannel);
+	transmitStruct<PedalAndTps>	(base + CAN_PEDAL_TPS_OFFSET, isExt, canChannel);
+	transmitStruct<Sensors1>	(base + CAN_SENSOR_1_OFFSET, isExt, canChannel);
+	transmitStruct<Sensors2>	(base + 4, isExt, canChannel);
+	transmitStruct<Fueling>		(base + 5, isExt, canChannel);
+	transmitStruct<Fueling2>	(base + 6, isExt, canChannel);
+	transmitStruct<Fueling3>	(base + 7, isExt, canChannel);
+	transmitStruct<Cams>		(base + 8, isExt, canChannel);
+	transmitStruct<Odometry>	(base + 9, isExt, canChannel);
 }
 
 #endif // EFI_CAN_SUPPORT

--- a/firmware/hw_layer/drivers/can/can_msg_tx.h
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.h
@@ -112,7 +112,7 @@ public:
 };
 
 template <typename TData>
-void transmitStruct(uint32_t id, bool isExtended, bool canChannel = false)
+void transmitStruct(uint32_t id, bool isExtended, bool canChannel)
 {
 	CanTxTyped<TData> frame(id, isExtended, canChannel);
 	// Destruction of an instance of CanTxMessage will transmit the message over the wire.

--- a/firmware/hw_layer/drivers/can/can_msg_tx.h
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.h
@@ -91,7 +91,7 @@ class CanTxTyped final : public CanTxMessage
 #endif // EFI_CAN_SUPPORT
 
 public:
-	explicit CanTxTyped(uint32_t id, bool isExtended) : CanTxMessage(id, sizeof(TData), isExtended) { }
+	explicit CanTxTyped(uint32_t id, bool isExtended, bool canChannel) : CanTxMessage(id, sizeof(TData), canChannel, isExtended) { }
 
 #if EFI_CAN_SUPPORT
 	/**
@@ -112,9 +112,9 @@ public:
 };
 
 template <typename TData>
-void transmitStruct(uint32_t id, bool isExtended)
+void transmitStruct(uint32_t id, bool isExtended, bool canChannel = false)
 {
-	CanTxTyped<TData> frame(id, isExtended);
+	CanTxTyped<TData> frame(id, isExtended, canChannel);
 	// Destruction of an instance of CanTxMessage will transmit the message over the wire.
 	// see CanTxMessage::~CanTxMessage()
 	populateFrame(frame.get());


### PR DESCRIPTION
pass the CAN bus via the `transmitStruct` to `CanTxMessage::CanTxMessage`, bus is by default 0, now looks at the setting from TS, `bool canBroadcastUseChannelTwo`.