### PR TITLE
Idle Target RPM in TS

### DIFF
--- a/firmware/integration/rusefi_config_shared.txt
+++ b/firmware/integration/rusefi_config_shared.txt
@@ -77,6 +77,7 @@
 #define GAUGE_NAME_ETB_ERROR "ETB: position error"
 #define GAUGE_NAME_ETB_DUTY "ETB: Duty"
 #define GAUGE_NAME_IDLE_POSITION "Idle: Position sensor"
+#define GAUGE_NAME_IDLE_RPM_TARGET "Idle: RPM Target"
 #define GAUGE_NAME_LAST_ERROR "Last error"
 #define GAUGE_NAME_TUNE_CRC16 "Tune CRC16"
 #define GAUGE_NAME_ENGINE_CRC16 "Engine CRC16"

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1287,6 +1287,7 @@ gaugeCategory = Idle
 	idleStatus_outputGauge = idleStatus_output,"Idle PID output", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_errorGauge = idleStatus_error,"Idle PID error", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_resetCounterGauge = idleStatus_resetCounter,"Idle PID resetCounter", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 0,0
+	targetRpmGauge = targetRpm, "Idle Target RPM - engine speed","RPM", 0, {rpmHardLimit + 2000}, 200, {cranking_rpm}, {rpmHardLimit - 500},  {rpmHardLimit},	0,	0
 
 gaugeCategory = ETB PID
 	etbStatus_pTermGauge = etbStatus_pTerm,"ETB 1 PID pTerm", "", -100.0,100.0, -100.0,100.0, -100.0,100.0, 3,3

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1287,7 +1287,7 @@ gaugeCategory = Idle
 	idleStatus_outputGauge = idleStatus_output,"Idle PID output", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_errorGauge = idleStatus_error,"Idle PID error", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_resetCounterGauge = idleStatus_resetCounter,"Idle PID resetCounter", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 0,0
-	targetRpmGauge = targetRpm, "Idle Target RPM - engine speed","RPM", 0, {rpmHardLimit + 2000}, 200, {cranking_rpm}, {rpmHardLimit - 500},  {rpmHardLimit},	0,	0
+	targetRpmGauge = targetRpm, @@GAUGE_NAME_IDLE_RPM_TARGET@@,"RPM", 0, {rpmHardLimit + 2000}, 200, {cranking_rpm}, {rpmHardLimit - 500},  {rpmHardLimit},	0,	0
 
 gaugeCategory = ETB PID
 	etbStatus_pTermGauge = etbStatus_pTerm,"ETB 1 PID pTerm", "", -100.0,100.0, -100.0,100.0, -100.0,100.0, 3,3


### PR DESCRIPTION
This makes idle target RPM available in TS. Can be helpful when dialing in idle calibration.