### PR TITLE
WiFi tweaks

### DIFF
--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -75,7 +75,6 @@ void TsChannelBase::writeCrcPacketLarge(const uint8_t responseCode, const uint8_
 	crc = crc32inc((void*)buf, crc, size);
 	*(uint32_t*)crcBuffer = SWAP_UINT32(crc);
 
-
 	// If data, write that
 	if (size) {
 		write(buf, size, /*isEndOfPacket*/false);

--- a/firmware/console/wifi_console.cpp
+++ b/firmware/console/wifi_console.cpp
@@ -37,7 +37,7 @@ public:
 	}
 
 	bool isReady() const override {
-		return true;
+		return socketReady;
 	}
 
 	void write(const uint8_t* buffer, size_t size, bool /*isEndOfPacket*/) final override {
@@ -65,7 +65,7 @@ public:
 	}
 };
 
-static WifiChannel wifiChannel;
+static NO_CACHE WifiChannel wifiChannel;
 
 class WifiHelperThread : public ThreadController<4096> {
 public:
@@ -85,7 +85,7 @@ public:
 	}
 };
 
-static WifiHelperThread wifiHelper;
+static NO_CACHE WifiHelperThread wifiHelper;
 
 static tstrWifiInitParam param;
 
@@ -104,7 +104,7 @@ void wifiCallback(uint8 u8MsgType, void* pvMsg) {
 	}
 }
 
-uint8_t rxBuf[512];
+static NO_CACHE uint8_t rxBuf[512];
 
 static void socketCallback(SOCKET sock, uint8_t u8Msg, void* pvMsg) {
 	switch (u8Msg) {
@@ -223,7 +223,7 @@ struct WifiConsoleThread : public TunerstudioThread {
 	}
 };
 
-static WifiConsoleThread wifiThread;
+static NO_CACHE WifiConsoleThread wifiThread;
 
 void startWifiConsole() {
 	iqObjectInit(&wifiIqueue, recvBuffer, sizeof(recvBuffer), nullptr, nullptr);


### PR DESCRIPTION
- Limit number of bytes written at once to the WiFi TCP API - you can't write more than 1400 bytes in one call, so chunk it when above that.
- Reset read queue in case of disconnect