### PR TITLE
KnockController: fix knock retard logic

### DIFF
--- a/firmware/controllers/engine_cycle/knock_controller.cpp
+++ b/firmware/controllers/engine_cycle/knock_controller.cpp
@@ -74,7 +74,7 @@ bool KnockControllerBase::onKnockSenseCompleted(uint8_t cylinderNumber, float db
 			// Adjust knock retard under lock
 			chibios_rt::CriticalSectionLocker csl;
 			auto newRetard = m_knockRetard + retardAmount;
-			m_knockRetard = clampF(0, newRetard, m_maximumRetard);
+			m_knockRetard = clampF(0, newRetard, getMaximumRetard());
 		}
 	}
 


### PR DESCRIPTION
fixes #246

----

use method to determine maximum retard, versus the member which is unused (in favor of max knock retard table)