### PR TITLE
GCC 13 simulator build, console->simulator on Linux

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -353,7 +353,7 @@ void unlockEcu(int password);
 // These externs aren't needed for unit tests - everything is injected instead
 #if !EFI_UNIT_TEST
 extern Engine ___engine;
-static Engine * const engine = &___engine;
+static constexpr Engine * const engine = &___engine;
 #else // EFI_UNIT_TEST
 extern Engine *engine;
 #endif // EFI_UNIT_TEST

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -32,7 +32,7 @@ public:
 	{
 	}
 
-	void start(CANDriver* device) {
+	void tryStart(CANDriver *device) {
 		m_device = device;
 
 		if (device) {
@@ -192,8 +192,8 @@ void initCan() {
 	}
 
 	if (engineConfiguration->canReadEnabled) {
-		canRead1.start(device1);
-		canRead2.start(device2);
+		canRead1.tryStart(device1);
+		canRead2.tryStart(device2);
 	}
 
 	isCanEnabled = true;

--- a/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
@@ -20,12 +20,11 @@ public class SimulatorExecHelper {
     /**
      * This is currently used by auto-tests only. Todo: reuse same code for UI-launched simulator?
      */
-    private static void runSimulator() {
+    private static void runSimulator(File binary) {
         Thread.currentThread().setName("Main simulation");
         FileLog.MAIN.logLine("runSimulator...");
 
         try {
-            File binary = getSimulatorBinary(SIMULATOR_BINARY_PATH);
             FileLog.MAIN.logLine("Binary size: " + binary.length());
 
             FileLog.MAIN.logLine("Executing " + binary.getPath());
@@ -94,10 +93,9 @@ public class SimulatorExecHelper {
     }
 
     public static void startSimulator() {
-        getSimulatorBinary(SIMULATOR_BINARY_PATH);
-
         FileLog.MAIN.logLine("startSimulator...");
-        new Thread(SimulatorExecHelper::runSimulator, "simulator process").start();
+        File simulatorBinary = getSimulatorBinary(SIMULATOR_BINARY_PATH);
+        new Thread(() -> SimulatorExecHelper.runSimulator(simulatorBinary), "simulator process").start();
     }
 
     public static File getSimulatorBinary(String binaryPath) {

--- a/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
@@ -13,8 +13,8 @@ import java.util.function.Consumer;
 public class SimulatorExecHelper {
     private final static NamedThreadFactory THREAD_FACTORY = new NamedThreadFactory("SimulatorExecHelper", true);
 
-    // see also SimulatorHelper
-    private static final String SIMULATOR_BINARY = "../simulator/build/fome_simulator.exe";
+    public static final String SIMULATOR_BINARY_NAME = "fome_simulator";
+    private static final String SIMULATOR_BINARY_PATH = "../simulator/build";
     static Process simulatorProcess;
 
     /**
@@ -25,10 +25,11 @@ public class SimulatorExecHelper {
         FileLog.MAIN.logLine("runSimulator...");
 
         try {
-            FileLog.MAIN.logLine("Binary size: " + new File(SIMULATOR_BINARY).length());
+            File binary = getSimulatorBinary();
+            FileLog.MAIN.logLine("Binary size: " + binary.length());
 
-            FileLog.MAIN.logLine("Executing " + SIMULATOR_BINARY);
-            SimulatorExecHelper.simulatorProcess = Runtime.getRuntime().exec(SIMULATOR_BINARY);
+            FileLog.MAIN.logLine("Executing " + binary.getPath());
+            SimulatorExecHelper.simulatorProcess = Runtime.getRuntime().exec(binary.getPath());
             FileLog.MAIN.logLine("simulatorProcess: " + SimulatorExecHelper.simulatorProcess);
 
             dumpProcessOutput(SimulatorExecHelper.simulatorProcess);
@@ -93,9 +94,25 @@ public class SimulatorExecHelper {
     }
 
     public static void startSimulator() {
-        if (!new File(SIMULATOR_BINARY).exists())
-            throw new IllegalStateException(SIMULATOR_BINARY + " not found");
+        getSimulatorBinary();
+
         FileLog.MAIN.logLine("startSimulator...");
         new Thread(SimulatorExecHelper::runSimulator, "simulator process").start();
+    }
+
+    private static File getSimulatorBinary() {
+        return getSimulatorBinary(SIMULATOR_BINARY_PATH + SIMULATOR_BINARY_NAME);
+    }
+
+    public static File getSimulatorBinary(String binaryPath) {
+        File binary = new File(binaryPath);
+
+        if (!binary.exists()) // try also for Windows/PE executable
+            binary = new File(binaryPath + ".exe");
+
+        if (!binary.exists() || binary.isDirectory() || !binary.canExecute())
+            throw new IllegalStateException("FOME Simulator program not found");
+
+        return binary;
     }
 }

--- a/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
@@ -101,11 +101,13 @@ public class SimulatorExecHelper {
     public static File getSimulatorBinary(String binaryPath) {
         File binary = new File(binaryPath + SIMULATOR_BINARY_NAME);
 
-        if (!binary.exists()) // try also for Windows/PE executable
+        if (!binary.exists()) { // try also for Windows/PE executable
             binary = new File(binaryPath + ".exe");
+        }
 
-        if (!binary.exists() || binary.isDirectory() || !binary.canExecute())
+        if (!binary.exists() || binary.isDirectory() || !binary.canExecute()) {
             throw new IllegalStateException("FOME Simulator program not found");
+        }
 
         return binary;
     }

--- a/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/SimulatorExecHelper.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 public class SimulatorExecHelper {
     private final static NamedThreadFactory THREAD_FACTORY = new NamedThreadFactory("SimulatorExecHelper", true);
 
-    public static final String SIMULATOR_BINARY_NAME = "fome_simulator";
+    private static final String SIMULATOR_BINARY_NAME = "fome_simulator";
     private static final String SIMULATOR_BINARY_PATH = "../simulator/build";
     static Process simulatorProcess;
 
@@ -25,7 +25,7 @@ public class SimulatorExecHelper {
         FileLog.MAIN.logLine("runSimulator...");
 
         try {
-            File binary = getSimulatorBinary();
+            File binary = getSimulatorBinary(SIMULATOR_BINARY_PATH);
             FileLog.MAIN.logLine("Binary size: " + binary.length());
 
             FileLog.MAIN.logLine("Executing " + binary.getPath());
@@ -94,18 +94,14 @@ public class SimulatorExecHelper {
     }
 
     public static void startSimulator() {
-        getSimulatorBinary();
+        getSimulatorBinary(SIMULATOR_BINARY_PATH);
 
         FileLog.MAIN.logLine("startSimulator...");
         new Thread(SimulatorExecHelper::runSimulator, "simulator process").start();
     }
 
-    private static File getSimulatorBinary() {
-        return getSimulatorBinary(SIMULATOR_BINARY_PATH + SIMULATOR_BINARY_NAME);
-    }
-
     public static File getSimulatorBinary(String binaryPath) {
-        File binary = new File(binaryPath);
+        File binary = new File(binaryPath + SIMULATOR_BINARY_NAME);
 
         if (!binary.exists()) // try also for Windows/PE executable
             binary = new File(binaryPath + ".exe");

--- a/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
@@ -14,6 +14,7 @@ import static com.rusefi.ui.util.UiUtils.setToolTip;
 
 public class SimulatorHelper {
     private final static ThreadFactory THREAD_FACTORY = new NamedThreadFactory("SimulatorHelper");
+    private static final String SIMULATOR_BINARY_PATH = "./";
     private static Process process;
 
     /**
@@ -23,7 +24,7 @@ public class SimulatorHelper {
     private static void startSimulator() {
         LinkManager.isSimulationMode = true;
 
-        File binary = SimulatorExecHelper.getSimulatorBinary("./" + SimulatorExecHelper.SIMULATOR_BINARY_NAME);
+        File binary = SimulatorExecHelper.getSimulatorBinary(SIMULATOR_BINARY_PATH);
 
         FileLog.MAIN.logLine("Executing " + binary.getPath());
         THREAD_FACTORY.newThread(new Runnable() {
@@ -60,7 +61,7 @@ public class SimulatorHelper {
 
     public static JComponent createSimulatorComponent(final StartupFrame portSelector) {
         try {
-            SimulatorExecHelper.getSimulatorBinary(SimulatorExecHelper.SIMULATOR_BINARY_NAME);
+            SimulatorExecHelper.getSimulatorBinary(SIMULATOR_BINARY_PATH);
         } catch (IllegalStateException e) {
             return new JLabel(e.getMessage());
         }

--- a/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
@@ -14,12 +14,7 @@ import static com.rusefi.ui.util.UiUtils.setToolTip;
 
 public class SimulatorHelper {
     private final static ThreadFactory THREAD_FACTORY = new NamedThreadFactory("SimulatorHelper");
-    public static final String BINARY = "fome_simulator.exe";
     private static Process process;
-
-    public static boolean isBinaryHere() {
-        return new File(BINARY).exists();
-    }
 
     /**
      * this code start sumulator for UI console
@@ -28,14 +23,16 @@ public class SimulatorHelper {
     private static void startSimulator() {
         LinkManager.isSimulationMode = true;
 
-        FileLog.MAIN.logLine("Executing " + BINARY);
+        File binary = SimulatorExecHelper.getSimulatorBinary("./" + SimulatorExecHelper.SIMULATOR_BINARY_NAME);
+
+        FileLog.MAIN.logLine("Executing " + binary.getPath());
         THREAD_FACTORY.newThread(new Runnable() {
             @Override
             public void run() {
                 try {
                     FileLog.SIMULATOR_CONSOLE.start();
-                    process = Runtime.getRuntime().exec(BINARY);
-                    FileLog.MAIN.logLine("Executing " + BINARY + "=" + process);
+                    process = Runtime.getRuntime().exec(binary.getPath());
+                    FileLog.MAIN.logLine("Executing " + binary.getPath() + "=" + process);
                     SimulatorExecHelper.dumpProcessOutput(process);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
@@ -62,8 +59,11 @@ public class SimulatorHelper {
     }
 
     public static JComponent createSimulatorComponent(final StartupFrame portSelector) {
-        if (!SimulatorHelper.isBinaryHere())
-            return new JLabel(SimulatorHelper.BINARY + " not found");
+        try {
+            SimulatorExecHelper.getSimulatorBinary(SimulatorExecHelper.SIMULATOR_BINARY_NAME);
+        } catch (IllegalStateException e) {
+            return new JLabel(e.getMessage());
+        }
 
         if (TcpConnector.isTcpPortOpened())
             return new JLabel("Port " + TcpConnector.DEFAULT_PORT + " already busy. Simulator running?");

--- a/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
@@ -21,10 +21,8 @@ public class SimulatorHelper {
      * this code start sumulator for UI console
      * todo: unify with the code which starts simulator for auto tests?
      */
-    private static void startSimulator() {
+    private static void startSimulator(File binary) {
         LinkManager.isSimulationMode = true;
-
-        File binary = SimulatorExecHelper.getSimulatorBinary(SIMULATOR_BINARY_PATH);
 
         FileLog.MAIN.logLine("Executing " + binary.getPath());
         THREAD_FACTORY.newThread(new Runnable() {
@@ -60,8 +58,9 @@ public class SimulatorHelper {
     }
 
     public static JComponent createSimulatorComponent(final StartupFrame portSelector) {
+        File simulatorBinary;
         try {
-            SimulatorExecHelper.getSimulatorBinary(SIMULATOR_BINARY_PATH);
+            simulatorBinary = SimulatorExecHelper.getSimulatorBinary(SIMULATOR_BINARY_PATH);
         } catch (IllegalStateException e) {
             return new JLabel(e.getMessage());
         }
@@ -74,7 +73,7 @@ public class SimulatorHelper {
             @Override
             public void actionPerformed(ActionEvent event) {
                 portSelector.disposeFrameAndProceed();
-                startSimulator();
+                startSimulator(simulatorBinary);
             }
         });
         setToolTip(simulatorButton, "Connect to totally virtual simulator",

--- a/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/SimulatorHelper.java
@@ -65,8 +65,9 @@ public class SimulatorHelper {
             return new JLabel(e.getMessage());
         }
 
-        if (TcpConnector.isTcpPortOpened())
+        if (TcpConnector.isTcpPortOpened()) {
             return new JLabel("Port " + TcpConnector.DEFAULT_PORT + " already busy. Simulator running?");
+        }
 
         JButton simulatorButton = new JButton("Start Virtual Simulator");
         simulatorButton.addActionListener(new ActionListener() {


### PR DESCRIPTION
GCC 13 produces [warnings as] errors (for x86/simulator)

also make console search non `.exe` suffixed binaries, for e.g. Linux