### PR TITLE
config [grammar] improves

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -46,7 +46,7 @@
 !
 !
 ! each field is declared as
-! type name;comment;scale,offset,min,max,number_of_digits
+! type name;comment;"units",scale,offset,min,max,number_of_digits
 ! hello;I like rusEFI;"ms",1,0,-10,10,2
 !
 !

--- a/java_tools/configuration_definition/src/main/antlr/RusefiConfigGrammar.g4
+++ b/java_tools/configuration_definition/src/main/antlr/RusefiConfigGrammar.g4
@@ -1,7 +1,7 @@
 grammar RusefiConfigGrammar;
 
 @header {
-	package com.rusefi.generated;
+    package com.rusefi.generated;
 }
 
 // ...be generous in line endings...
@@ -54,13 +54,13 @@ integer: IntegerChars;
 floatNum: FloatChars | IntegerChars;
 
 expr
-    : floatNum			# EvalNumber
-    | '{' expr '}'		# EvalParens
-    | expr MUL expr		# EvalMul
-	| expr DIV expr		# EvalDiv
-	| expr ADD expr		# EvalAdd
-	| expr SUB expr		# EvalSub
-    | replacementIdent	# EvalReplacement
+    : floatNum          # EvalNumber
+    | '{' expr '}'      # EvalParens
+    | expr MUL expr     # EvalMul
+    | expr DIV expr     # EvalDiv
+    | expr ADD expr     # EvalAdd
+    | expr SUB expr     # EvalSub
+    | replacementIdent  # EvalReplacement
     ;
 
 numexpr: expr;
@@ -121,8 +121,8 @@ enumRhs
     | enumVal (',' enumVal)*
     ;
 
-enumTypedefSuffix: /*ignored*/replacementIdent Bits ',' Datatype ',' '@OFFSET@' ',' '[' integer ':' integer ']' ',' enumRhs ;
-scalarTypedefSuffix: /*ignored*/integer Scalar ',' Datatype ',' '@OFFSET@' fieldOptionsList ;
+enumTypedefSuffix: /*ignored*/replacementIdent Bits ',' Datatype ',' '@OFFSET@' ',' '[' integer ':' integer ']' ',' enumRhs;
+scalarTypedefSuffix: /*ignored*/integer Scalar ',' Datatype ',' '@OFFSET@' fieldOptionsList;
 stringTypedefSuffix: /*ignored*/replacementIdent 'string' ',' 'ASCII' ',' '@OFFSET@' ',' numexpr;
 
 typedef: Custom identifier (enumTypedefSuffix | scalarTypedefSuffix | stringTypedefSuffix);


### PR DESCRIPTION
just some tidying; mainly was curious what the missing field in the type description is

seems this is a "legacy" field-options declaration -- perhaps we can finish the TODOs in the grammar and convert all of the config descriptions to not use these "legacy" specs