### PR TITLE
-Werror=stringop-overflow

### DIFF
--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -7,4 +7,4 @@ RUSEFI_OPT += -Wno-error=unused-function
 RUSEFI_OPT += -Wno-error=sign-compare
 RUSEFI_OPT += -Wno-error=unused-parameter
 RUSEFI_OPT += -Wno-error=undef
-RUSEFI_OPT += -Wno-error=stringop-overflow
+


### PR DESCRIPTION
`if you get ... fault at a particular optimization level, you're probably relying on undefined behavior somewhere`