### PR TITLE
fix overdwell in case of noisy trigger

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -45,6 +45,7 @@ or
  - Displayed units in TunerStudio change when switching between volume vs. mass injector flow modes #42
  - Make Toyota "3 Tooth Cam" decoder more robust #382
  - Flex sensor-derived fuel temperature indication works properly
+ - Fix a scenario where noisy trigger can cause overdwell rusefi/rusefi#6349
 
 ## December 2023 Release
 

--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -45,7 +45,7 @@ or
  - Displayed units in TunerStudio change when switching between volume vs. mass injector flow modes #42
  - Make Toyota "3 Tooth Cam" decoder more robust #382
  - Flex sensor-derived fuel temperature indication works properly
- - Fix a scenario where noisy trigger can cause overdwell rusefi/rusefi#6349
+ - Fix a scenario where noisy trigger can cause overdwell [rusefi/rusefi#6349](https://github.com/rusefi/rusefi/issues/6349)
 
 ## December 2023 Release
 

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -24,24 +24,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <rusefi/isnan.h>
-#include <rusefi/math.h>
+#include "pch.h"
 
 #include "global_shared.h"
-#include "loggingcentral.h"
-#include "error_handling.h"
-#include "perf_trace.h"
-
 #include "engine_configuration.h"
 
-#include "trigger_central.h"
-#include "trigger_decoder.h"
-/**
- * decoder depends on current RPM for error condition logic
- */
-#include "sensor.h"
-#include "engine_state.h"
-#include "engine_math.h"
 /**
  * decoder uses TriggerStimulatorHelper in findTriggerZeroEventIndex
  */
@@ -261,8 +248,14 @@ void PrimaryTriggerDecoder::onTriggerError() {
 	// On trigger error, we've lost full sync
 	resetHasFullSync();
 
-	// Instant RPM data is now also probably trash
-	getTriggerCentral()->instantRpm.resetInstantRpm();
+	// Ignore the warning that engine is never null - it might be in unit tests
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Waddress"
+		if (engine) {
+			// Instant RPM data is now also probably trash, discard it
+			engine->triggerCentral.instantRpm.resetInstantRpm();
+		}
+	#pragma GCC diagnostic pop
 }
 
 void PrimaryTriggerDecoder::onNotEnoughTeeth(int /*actual*/, int /*expected*/) {

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -260,6 +260,9 @@ bool PrimaryTriggerDecoder::hasSynchronizedPhase() const {
 void PrimaryTriggerDecoder::onTriggerError() {
 	// On trigger error, we've lost full sync
 	resetHasFullSync();
+
+	// Instant RPM data is now also probably trash
+	getTriggerCentral()->instantRpm.resetInstantRpm();
 }
 
 void PrimaryTriggerDecoder::onNotEnoughTeeth(int /*actual*/, int /*expected*/) {

--- a/unit_tests/global_execution_queue.cpp
+++ b/unit_tests/global_execution_queue.cpp
@@ -25,7 +25,7 @@ void TestExecutor::scheduleForLater(const char *msg, scheduling_s *scheduling, i
 		return;
 	}
 
-	scheduleByTimestamp("test", scheduling, getTimeNowUs() + delayUs, action);
+	scheduleByTimestamp(msg, scheduling, getTimeNowUs() + delayUs, action);
 }
 
 int TestExecutor::executeAll(efitick_t now) {
@@ -54,7 +54,7 @@ void TestExecutor::scheduleByTimestamp(const char *msg, scheduling_s *scheduling
 	}
 
 	if (m_mockExecutor) {
-		m_mockExecutor->scheduleByTimestamp("test", scheduling, timeUs, action);
+		m_mockExecutor->scheduleByTimestamp(msg, scheduling, timeUs, action);
 		return;
 	}
 
@@ -67,7 +67,7 @@ void TestExecutor::scheduleByTimestampNt(const char *msg, scheduling_s* scheduli
 		return;
 	}
 
-	scheduleByTimestamp("test", scheduling, NT2US(timeNt), action);
+	scheduleByTimestamp(msg, scheduling, NT2US(timeNt), action);
 }
 
 void TestExecutor::cancel(scheduling_s* s) {


### PR DESCRIPTION
If you were lucky with your noisy trigger AND had "always instant rpm" turned on, you could get long dwell times due to bogus RPM indication from instant RPM.

fix rusefi/rusefi#6349