### PR TITLE
build OpenBLT bootloader with nucleo_f429 board

### DIFF
--- a/firmware/config/boards/nucleo_f429/compile_stm32f429_nucleo.sh
+++ b/firmware/config/boards/nucleo_f429/compile_stm32f429_nucleo.sh
@@ -5,4 +5,6 @@
 SCRIPT_NAME="compile_nucleo_f429.sh"
 echo "Entering $SCRIPT_NAME"
 
+export USE_OPENBLT=yes
+
 bash ../common_make.sh nucleo_f429 ARCH_STM32F4


### PR DESCRIPTION
maybe unnecessary, but I wanted to play with it and releases do not include it

FOME Console does not support DFU things on Linux, so wanted to discover about OpenBLT based FOME