### PR TITLE
fix knock retard table init

### DIFF
--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -490,6 +490,8 @@ void commonInitEngineController() {
 
 	initTachometer();
 	initSpeedometer();
+
+	initKnockCtrl();
 }
 
 // Returns false if there's an obvious problem with the loaded configuration

--- a/firmware/controllers/engine_cycle/knock_controller.cpp
+++ b/firmware/controllers/engine_cycle/knock_controller.cpp
@@ -8,14 +8,14 @@
 #include "pch.h"
 #include "knock_logic.h"
 
-void KnockController::init(engine_configuration_s const * const previousConfig) {
+void KnockController::init() {
 	m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardLoadBins, config->maxKnockRetardRpmBins);
 }
 
 void KnockController::onConfigurationChange(engine_configuration_s const * previousConfig) {
 	KnockControllerBase::onConfigurationChange(previousConfig);
 
-	init(previousConfig);
+	init();
 }
 
 int getCylinderKnockBank(uint8_t cylinderNumber) {
@@ -167,5 +167,5 @@ void Engine::onSparkFireKnockSense(uint8_t cylinderNumber, efitick_t nowNt) {
 }
 
 void initKnockCtrl() {
-	engine->module<KnockController>().unmock().init(engineConfiguration);
+	engine->module<KnockController>().unmock().init();
 }

--- a/firmware/controllers/engine_cycle/knock_controller.cpp
+++ b/firmware/controllers/engine_cycle/knock_controller.cpp
@@ -8,10 +8,14 @@
 #include "pch.h"
 #include "knock_logic.h"
 
+void KnockController::init(engine_configuration_s const * const previousConfig) {
+	m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardLoadBins, config->maxKnockRetardRpmBins);
+}
+
 void KnockController::onConfigurationChange(engine_configuration_s const * previousConfig) {
 	KnockControllerBase::onConfigurationChange(previousConfig);
 
-	m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardLoadBins, config->maxKnockRetardRpmBins);
+	init(previousConfig);
 }
 
 int getCylinderKnockBank(uint8_t cylinderNumber) {
@@ -160,4 +164,8 @@ void Engine::onSparkFireKnockSense(uint8_t cylinderNumber, efitick_t nowNt) {
 #else
 	UNUSED(nowNt);
 #endif
+}
+
+void initKnockCtrl() {
+	engine->module<KnockController>().unmock().init(engineConfiguration);
 }

--- a/firmware/controllers/engine_cycle/knock_controller.cpp
+++ b/firmware/controllers/engine_cycle/knock_controller.cpp
@@ -11,7 +11,7 @@
 void KnockController::onConfigurationChange(engine_configuration_s const * previousConfig) {
 	KnockControllerBase::onConfigurationChange(previousConfig);
 
-	m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardRpmBins, config->maxKnockRetardLoadBins);
+	m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardLoadBins, config->maxKnockRetardRpmBins);
 }
 
 int getCylinderKnockBank(uint8_t cylinderNumber) {

--- a/firmware/controllers/engine_cycle/knock_logic.h
+++ b/firmware/controllers/engine_cycle/knock_logic.h
@@ -41,6 +41,7 @@ public:
 	KnockController()
 	{
 	}
+	void init(engine_configuration_s const * const previousConfig);
 
 	void onConfigurationChange(engine_configuration_s const * /*previousConfig*/) override;
 
@@ -50,3 +51,5 @@ public:
 private:
 	Map3D<6, 6, uint8_t, uint8_t, uint8_t> m_maxRetardTable;
 };
+
+void initKnockCtrl();

--- a/firmware/controllers/engine_cycle/knock_logic.h
+++ b/firmware/controllers/engine_cycle/knock_logic.h
@@ -41,7 +41,7 @@ public:
 	KnockController()
 	{
 	}
-	void init(engine_configuration_s const * const previousConfig);
+	void init();
 
 	void onConfigurationChange(engine_configuration_s const * /*previousConfig*/) override;
 


### PR DESCRIPTION
column and row definition were swapped w/re: value lookup

fixes #246, #417

----

Andrey was right: https://github.com/FOME-Tech/fome-fw/issues/417#issuecomment-2087816779
> is this https://github.com/rusefi/rusefi/issues/6370?

Comparison to boost; RPM is columns:
![2024-05-02_02h00m55s_screenshot](https://github.com/FOME-Tech/fome-fw/assets/8540239/ba875731-ce6c-443e-8cc2-009aac7b905c)

boost:
```cxx
// init
boostMapOpen.init(config->boostTableOpenLoop, config->boostTpsBins, config->boostRpmBins);
boostMapClosed.init(config->boostTableClosedLoop, config->boostTpsBins, config->boostRpmBins);

// getValue
float openLoop = luaOpenLoopAdd + m_openLoopMap->getValue(rpm, driverIntent.Value);
float target = m_closedLoopTargetMap->getValue(rpm, driverIntent.Value);
```

knock:
```cxx
// init
m_maxRetardTable.init(config->maxKnockRetardTable, config->maxKnockRetardRpmBins, config->maxKnockRetardLoadBins);

// getValue
return m_maxRetardTable.getValue(Sensor::getOrZero(SensorType::Rpm), getIgnitionLoad());
```