### PR TITLE
fix building firmware on linux

### DIFF
--- a/firmware/use_arm_gcc.mk
+++ b/firmware/use_arm_gcc.mk
@@ -1,12 +1,15 @@
 ifeq ($(TRGT),)
-	UNAME_S := $(shell uname -s)
 	UNAME_SM := $(shell uname -sm)
 $(info UNAME_SM:          $(UNAME_SM))
+	KERNEL := $(firstword $(UNAME_SM))
+	MACHINE := $(lastword $(UNAME_SM))
 
-	ifeq ($(UNAME_S),Darwin)
+	ifeq ($(KERNEL),Darwin)
 		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi
-	else ifeq ($(UNAME_SM),Linux x86_64)
-		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
+	else ifeq ($(KERNEL),Linux)
+		ifeq ($(MACHINE),x86_64)
+			COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
+		endif
 	else
 $(error Looks like your platform, $(UNAME_SM), doesn't have a supported compiler!)
 	endif
@@ -14,17 +17,17 @@ $(error Looks like your platform, $(UNAME_SM), doesn't have a supported compiler
 	BUILD_TOOLS_DIR = $(PROJECT_DIR)/ext/build-tools/
 	TRGT = $(BUILD_TOOLS_DIR)$(COMPILER_PLATFORM)/bin/arm-none-eabi-
 
-# If the compiler doesn't exist, try to update the build tools submodule
-ifeq ("$(wildcard $(TRGT)g++)","")
+	# If the compiler doesn't exist, try to update the build tools submodule
+	ifeq ("$(wildcard $(TRGT)g++)","")
 $(info Compiler at $(TRGT)g++ not found, trying to update build-tools submodule...")
 $(shell git submodule update --init --depth=1 $(BUILD_TOOLS_DIR))
 $(error Please re-run make to execute build!)
-endif
+	endif
 else
-# If the compiler doesn't exist, fault now
-ifeq ("$(wildcard $(TRGT)g++)","")
+	# If the compiler doesn't exist, fault now
+	ifeq ("$(wildcard $(TRGT)g++)","")
 $(error Compiler not found at $(TRGT)g++!)
-endif
+	endif
 endif
 
 $(info COMPILER_PLATFORM: $(COMPILER_PLATFORM))

--- a/firmware/use_arm_gcc.mk
+++ b/firmware/use_arm_gcc.mk
@@ -1,14 +1,14 @@
 ifeq ($(TRGT),)
 	UNAME_S := $(shell uname -s)
-	UNAME_SP := $(shell uname -sp)
-$(info UNAME_SP:          $(UNAME_SP))
+	UNAME_SM := $(shell uname -sm)
+$(info UNAME_SM:          $(UNAME_SM))
 
 	ifeq ($(UNAME_S),Darwin)
 		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi
-	else ifeq ($(UNAME_SP),Linux x86_64)
+	else ifeq ($(UNAME_SM),Linux x86_64)
 		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
 	else
-$(error Looks like your platform, $(UNAME_SP), doesn't have a supported compiler!)
+$(error Looks like your platform, $(UNAME_SM), doesn't have a supported compiler!)
 	endif
 
 	BUILD_TOOLS_DIR = $(PROJECT_DIR)/ext/build-tools/

--- a/firmware/use_arm_gcc.mk
+++ b/firmware/use_arm_gcc.mk
@@ -1,15 +1,11 @@
 ifeq ($(TRGT),)
 	UNAME_SM := $(shell uname -sm)
 $(info UNAME_SM:          $(UNAME_SM))
-	KERNEL := $(firstword $(UNAME_SM))
-	MACHINE := $(lastword $(UNAME_SM))
 
-	ifeq ($(KERNEL),Darwin)
+	ifeq ($(firstword $(UNAME_SM)),Darwin)
 		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi
-	else ifeq ($(KERNEL),Linux)
-		ifeq ($(MACHINE),x86_64)
-			COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
-		endif
+	else ifeq ($(UNAME_SM),Linux x86_64)
+		COMPILER_PLATFORM = arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
 	else
 $(error Looks like your platform, $(UNAME_SM), doesn't have a supported compiler!)
 	endif


### PR DESCRIPTION
`--processor` is non-portable, and systems like Kali and Debian do not play games like Ubuntu et al which e.g. patch to `--machine`

~~Also support Linux AArch64 (arm64) host~~