### PR TITLE
idle stepper TS panel disable should not depend ETB functions

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3260,8 +3260,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	dialog = stepperHbridgeHardware, "Stepper H-Bridge Hardware"
 		topicHelp = "stepperHbridgeHardwareHelp"
 		field = "Inverted driver pins",					stepperDcInvertedPins
-		panel = stepperHbridgeHardwareNo1, { etbFunctions1 != @@dc_function_e_DC_None@@ }
-		panel = stepperHbridgeHardwareNo2, { etbFunctions2 != @@dc_function_e_DC_None@@ }
+		panel = stepperHbridgeHardwareNo1
+		panel = stepperHbridgeHardwareNo2
 
 	dialog = idleStepperHw, "Stepper Controller Hardware"
 		topicHelp = "idleStepperHwHelp"


### PR DESCRIPTION
it seems https://github.com/rusefi/rusefi/pull/4904/files may have been merged without thorough review

does this change make sense?  configuring idle stepper hardware should not depend on ETB function/configuration, right?

also, perhaps still an issue exists if both ETB and idle stepper are trying to use the same hardware?