### PR TITLE
simulator: more arguments

### DIFF
--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run Linux Simulator for 10 seconds
       working-directory: ./simulator/
-      run: ./build/fome_simulator 10
+      run: ./build/fome_simulator --timeout 10
 
     - name: Upload Linux built simulator
       uses: actions/upload-artifact@v4

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,4 +1,4 @@
-Win32 or posix version of firmware allows to explore rusEFI on a PC without any embedded hardware!
+Win32 or POSIX version of firmware allows to explore FOME on a PC without any embedded hardware!
 
 Simulator runs a subset of ECU on your pc, easier to debug some things, tighter dev loop.
 
@@ -6,4 +6,3 @@ Simulator runs a subset of ECU on your pc, easier to debug some things, tighter 
 * mocked analog sensors
 * mocked outputs
 * SocketCAN integration on Linux
-

--- a/simulator/libc_argp.h
+++ b/simulator/libc_argp.h
@@ -6,22 +6,23 @@ static char doc[] =
     "FOME Simulator -- https://wiki.fome.tech/";
 
 /* A description of the arguments we accept. */
-static char args_doc[] = "[TIMEOUT]";
+static char args_doc[] = "";
 
 /* The options we understand. */
 static struct argp_option options[] = {
     {"quiet", 'q', 0,         0, "Don't produce verbose output", 0 },
     {"socketcan-device",
                 'd', "DEVICE",  0, "SocketCAN DEVICE (default: can0) to use", 0 },
+    {"timeout", 't', "SECONDS", 0, "Run for SECONDS and then exit (negative values ignored)", 0 },
     { 0, 0, 0, 0, 0, 0 }
 };
 
 /* Used by main to communicate with parse_opt. */
 struct arguments
 {
-    int timeout;
     int quiet;
     char * socketcanDevice;
+    int timeout;
 };
 
 /* Parse a single option. */
@@ -39,13 +40,15 @@ parse_opt(int key, char * arg, struct argp_state * state)
         case 'q':
             arguments->quiet = 1;
             break;
+        case 't':
+            arguments->timeout = atoi(arg);
+            break;
 
         case ARGP_KEY_ARG:
-            if (state->arg_num >= 1) {
+            /* if (state->arg_num >= 0) */ {
                 /* Too many arguments. */
                 argp_usage(state);
             }
-            arguments->timeout = atoi(arg);
             break;
 
         case ARGP_KEY_END:

--- a/simulator/libc_argp.h
+++ b/simulator/libc_argp.h
@@ -10,7 +10,7 @@ static char args_doc[] = "[TIMEOUT]";
 
 /* The options we understand. */
 static struct argp_option options[] = {
-    {"verbose", 'v', 0,         0, "Produce verbose output (default)", 0 },
+    {"quiet", 'q', 0,         0, "Don't produce verbose output", 0 },
     {"socketcan-device",
                 'd', "DEVICE",  0, "SocketCAN DEVICE (default: can0) to use", 0 },
     { 0, 0, 0, 0, 0, 0 }
@@ -20,7 +20,7 @@ static struct argp_option options[] = {
 struct arguments
 {
     int timeout;
-    int verbose;
+    int quiet;
     char * socketcanDevice;
 };
 
@@ -33,11 +33,11 @@ parse_opt(int key, char * arg, struct argp_state * state)
     struct arguments * arguments = (struct arguments *)state->input;
 
     switch (key) {
-        case 'v':
-            arguments->verbose = 1;
-            break;
         case 'd':
             arguments->socketcanDevice = arg;
+            break;
+        case 'q':
+            arguments->quiet = 1;
             break;
 
         case ARGP_KEY_ARG:

--- a/simulator/libc_argp.h
+++ b/simulator/libc_argp.h
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <argp.h>
+
+/* Program documentation. */
+static char doc[] =
+    "FOME Simulator -- https://wiki.fome.tech/";
+
+/* A description of the arguments we accept. */
+static char args_doc[] = "[TIMEOUT]";
+
+/* The options we understand. */
+static struct argp_option options[] = {
+    {"verbose", 'v', 0,         0, "Produce verbose output (default)", 0 },
+    {"socketcan-device",
+                'd', "DEVICE",  0, "SocketCAN DEVICE (default: can0) to use", 0 },
+    { 0, 0, 0, 0, 0, 0 }
+};
+
+/* Used by main to communicate with parse_opt. */
+struct arguments
+{
+    int timeout;
+    int verbose;
+    char * socketcanDevice;
+};
+
+/* Parse a single option. */
+static error_t
+parse_opt(int key, char * arg, struct argp_state * state)
+{
+    /* Get the input argument from argp_parse, which we
+       know is a pointer to our arguments structure. */
+    struct arguments * arguments = (struct arguments *)state->input;
+
+    switch (key) {
+        case 'v':
+            arguments->verbose = 1;
+            break;
+        case 'd':
+            arguments->socketcanDevice = arg;
+            break;
+
+        case ARGP_KEY_ARG:
+            if (state->arg_num >= 1) {
+                /* Too many arguments. */
+                argp_usage(state);
+            }
+            arguments->timeout = atoi(arg);
+            break;
+
+        case ARGP_KEY_END:
+        case ARGP_KEY_NO_ARGS:
+            break;
+
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+/* Our argp parser. */
+static struct argp argp = { options, parse_opt, args_doc, doc, 0, 0, 0 };

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char** argv) {
 	cputs("  - Listening for connections on SD2");
 	chEvtRegister(chnGetEventSource(&SD2), &sd2fel, 2);
 
-	rusEfiFunctionalTest();
+	rusEfiFunctionalTest(arguments.socketcanDevice);
 
 	/*
 	 * Events servicing loop.

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -146,11 +146,11 @@ int main(int argc, char** argv) {
 
 	struct arguments arguments;
 	arguments.timeout = -1;
-	arguments.verbose = 1;
+	arguments.quiet = 0;
 	arguments.socketcanDevice = (char *)"can0";
 	argp_parse(&argp, argc, argv, 0, 0, &arguments);
 
-	verboseMode = arguments.verbose != 0;
+	verboseMode = arguments.quiet == 0;
 
 	/*
 	 * System initializations.

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -145,9 +145,9 @@ int main(int argc, char** argv) {
 	setbuf(stdout, NULL);
 
 	struct arguments arguments;
-	arguments.timeout = -1;
 	arguments.quiet = 0;
 	arguments.socketcanDevice = (char *)"can0";
+	arguments.timeout = -1;
 	argp_parse(&argp, argc, argv, 0, 0, &arguments);
 
 	verboseMode = arguments.quiet == 0;

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -18,6 +18,7 @@
 #include "chprintf.h"
 #include "rusEfiFunctionalTest.h"
 #include "flash_int.h"
+#include "libc_argp.h"
 
 #include <iostream>
 #include <filesystem>
@@ -143,6 +144,14 @@ static virtual_timer_t exitTimer;
 int main(int argc, char** argv) {
 	setbuf(stdout, NULL);
 
+	struct arguments arguments;
+	arguments.timeout = -1;
+	arguments.verbose = 1;
+	arguments.socketcanDevice = (char *)"can0";
+	argp_parse(&argp, argc, argv, 0, 0, &arguments);
+
+	verboseMode = arguments.verbose != 0;
+
 	/*
 	 * System initializations.
 	 * - HAL initialization, this also initializes the configured device drivers
@@ -153,12 +162,10 @@ int main(int argc, char** argv) {
 	halInit();
 	chSysInit();
 
-	if (argc == 2) {
-		int timeoutSeconds = atoi(argv[1]);
-		printf("Running rusEFI simulator for %d seconds, then exiting.\n\n", timeoutSeconds);
-
+	if (arguments.timeout >= 0) {
+		printf("Running rusEFI simulator for %d seconds, then exiting.\n\n", arguments.timeout);
 		chSysLock();
-		chVTSetI(&exitTimer, MY_US2ST(timeoutSeconds * 1e6), [](void*) { exit(0); }, nullptr);
+		chVTSetI(&exitTimer, MY_US2ST(arguments.timeout * 1e6), [](void *) { exit(0); }, nullptr);
 		chSysUnlock();
 	}
 

--- a/simulator/simulator/README.md
+++ b/simulator/simulator/README.md
@@ -1,0 +1,1 @@
+Here we have FOME PC version ("simulator"). Same Makefile would build Win32 or \*nix/POSIX.

--- a/simulator/simulator/readme.md
+++ b/simulator/simulator/readme.md
@@ -1,1 +1,0 @@
-Here we have rusEfi PC version. Same Makefile would build win32 or unux posix. 

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -84,7 +84,7 @@ static void runChprintfTest() {
 
 }
 
-void rusEfiFunctionalTest(void) {
+void rusEfiFunctionalTest(char const * const socketcanDevice) {
 	printToConsole("Running rusEfi simulator version:");
 	static char versionBuffer[20];
 	itoa10(versionBuffer, (int)getRusEfiVersion());
@@ -128,8 +128,8 @@ void rusEfiFunctionalTest(void) {
 
 #if HAL_USE_CAN
 	// Set CAN device name
-	CAND1.deviceName = "can0";
-
+	CAND1.deviceName = socketcanDevice;
+	printf("Using SocketCAN device: %s\n", CAND1.deviceName);
 	initCan();
 #endif // HAL_USE_CAN
 

--- a/simulator/simulator/rusEfiFunctionalTest.h
+++ b/simulator/simulator/rusEfiFunctionalTest.h
@@ -7,6 +7,6 @@
 
 #pragma once
 
-void rusEfiFunctionalTest(void);
+void rusEfiFunctionalTest(char const * const socketcanDevice);
 void printPendingMessages(void);
 void logMsg(const char *fmt, ...);


### PR DESCRIPTION
- use [Argp](https://www.gnu.org/software/libc/manual/html_node/Argp.html) to parse arguments
- allow to specify SocketCAN device (`--socketcan-device`/`-d`)
- make timeout argument an option (`--timeout`/`-t`)
- allow to disable verbosity (`--quiet`/`-q`)