### PR TITLE
oil pressure protection (while running)

### DIFF
--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -109,6 +109,9 @@ void setDefaultBaseEngine() {
 
 	setDefaultVrThresholds();
 
+	// Oil pressure protection
+	engineConfiguration->minimumOilPressureTimeout = 0.5f;
+	setLinearCurve(config->minimumOilPressureBins, 0, 7000);
 }
 
 void setPPSInputs(adc_channel_e pps1, adc_channel_e pps2) {

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -664,6 +664,10 @@ bool validateConfig() {
 	}
 #endif
 
+	if (engineConfiguration->enableOilPressureProtect) {
+		ensureArrayIsAscending("Oil pressure protection", config->minimumOilPressureBins);
+	}
+
 	return true;
 }
 

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -157,6 +157,9 @@ private:
 
 	// Tracks how long injector duty has been over the sustained limit
 	Timer m_injectorDutySustainedTimer;
+
+	// Tracks how long oil pressure has been below threshold
+	Timer m_lowOilPressureTimer;
 };
 
 LimpManager * getLimpManager();

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -779,7 +779,7 @@ custom uart_device_e 1 bits, U08, @OFFSET@, [0:1], "Off", "UART1", "UART2", "UAR
 	pin_output_mode_e acRelayPinMode;
 	output_pin_e acRelayPin;
 
-	uint8_t unused754
+	uint8_t autoscale minimumOilPressureTimeout;Delay before cutting fuel due to low oil pressure. Use this to ignore short pressure blips and sensor noise.;"sec", 0.1, 0, 0, 5, 1
 
 	spi_device_e drv8860spiDevice;
 
@@ -826,7 +826,7 @@ sensor_chart_e sensorChartMode;rusEFI console Sensor Sniffer mode;
 	bit enableLaunchRetard
 	bit enableCanVss;Read VSS from OEM CAN bus according to selected CAN vehicle configuration.
 	bit enableInnovateLC2
-	bit unused808b7
+	bit enableOilPressureProtect
 	bit stftIgnoreErrorMagnitude;If enabled, adjust at a constant rate instead of a rate proportional to the current lambda error. This mode may be easier to tune, and more tolerant of sensor noise.
 	bit enableSoftwareKnock
 	bit verboseVVTDecoding;Verbose info in console below engineSnifferRpmThreshold\nenable vvt_details
@@ -1730,6 +1730,9 @@ uint8_t[FUEL_LEVEL_TABLE_COUNT] fuelLevelValues;;"%", 1, 0, 0, 100, 0
 
 uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrVoltBins;;"volts", 0.1, 0, 0, 20, 1
 uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrValues;;"multiplier", 0.02, 0, 0, 5, 2
+
+uint8_t[8] autoscale minimumOilPressureBins;;"RPM", 100, 0, 0, 25000, 0
+uint8_t[8] autoscale minimumOilPressureValues;;"kPa", 10, 0, 0, 1000, 0
 
 end_struct
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -806,7 +806,7 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		yAxis = 0, 500, 6
 		xBins = minimumOilPressureBins, RPMValue
 		yBins = minimumOilPressureValues
-		gauge = RPMGauge
+		gauge = OilPressGauge
 
 [TableEditor]
 	;		table_id,	map3d_id,	"title",		page

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -800,6 +800,14 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		yBins = throttleEstimateEffectiveAreaValues
 		gauge = TPSGauge
 
+	curve = minimumOilPressure, "Minimum oil pressure"
+		columnLabel = "RPM", "min pressure"
+		xAxis = 0, 8000, 9
+		yAxis = 0, 500, 6
+		xBins = minimumOilPressureBins, RPMValue
+		yBins = minimumOilPressureValues
+		gauge = RPMGauge
+
 [TableEditor]
 	;		table_id,	map3d_id,	"title",		page
 
@@ -3805,6 +3813,9 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 	dialog = oilPressureProtection, "Oil pressure protection"
 		field = "Minimum oil pressure after start",		minOilPressureAfterStart
+		field = "Enable low oil pressure protection",	enableOilPressureProtect
+		field = "Oil pressure protection timeout", 		minimumOilPressureTimeout
+		panel = minimumOilPressure
 
 	dialog = etbLimits, "Electronic Throttle Limiting"
 		field = "Smoothly close the throttle to limit RPM."


### PR DESCRIPTION
add a table for minimum oil pressure vs. RPM, and a timeout for how long below threshold to cut fueling