### PR TITLE
Odd cylinder engine wasted spark

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -43,6 +43,7 @@ or
  - TunerStudio UI improvements (#436, etc)
  - Dropdown selector for popular gearbox ratios (#358, thank you @alrijleh and @nmschulte!)
  - Add two more aux linear sensors #476
+ - Support wasted spark on odd cylinder count 4-stroke engines. Improves startup and allows running without a cam sensor!
 
 ### Fixed
  - Improve performance with Lua CAN reception of a high volume of frames

--- a/firmware/controllers/algo/engine_state.h
+++ b/firmware/controllers/algo/engine_state.h
@@ -24,6 +24,8 @@ public:
 	 */
 	angle_t engineCycle;
 
+	bool useOddFireWastedSpark = false;
+
 	/**
 	 * this is based on sensorChartMode and sensorSnifferRpmThreshold settings
 	 */

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -105,10 +105,10 @@ static void prepareCylinderIgnitionSchedule(angle_t dwellAngleDuration, floatms_
 
 	auto ignitionMode = getCurrentIgnitionMode();
 
-	// On an odd cylinder wasted spark engine, map outputs as if in sequential.
+	// On an odd cylinder (or odd fire) wasted spark engine, map outputs as if in sequential.
 	// During actual scheduling, the events just get scheduled every 360 deg instead
 	// of every 720 deg.
-	if (ignitionMode == IM_WASTED_SPARK && (engineConfiguration->cylindersCount % 2 == 1)) {
+	if (ignitionMode == IM_WASTED_SPARK && engine->engineState.useOddFireWastedSpark) {
 		ignitionMode = IM_INDIVIDUAL_COILS;
 	}
 
@@ -475,9 +475,8 @@ void onTriggerEventSparkLogic(int rpm, efitick_t edgeTimestamp, float currentPha
 	// - current mode is wasted spark
 	// - four stroke
 	bool enableOddCylinderWastedSpark =
-		(engineConfiguration->cylindersCount % 2 == 1) 
-		&& getCurrentIgnitionMode() == IM_WASTED_SPARK
-		&& engine->engineState.engineCycle == 720;
+		engine->engineState.useOddFireWastedSpark
+		&& getCurrentIgnitionMode() == IM_WASTED_SPARK;
 
 	if (engine->ignitionEvents.isReady) {
 		for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -479,7 +479,6 @@ void onTriggerEventSparkLogic(int rpm, efitick_t edgeTimestamp, float currentPha
 		&& getCurrentIgnitionMode() == IM_WASTED_SPARK
 		&& engine->engineState.engineCycle == 720;
 
-//	scheduleSimpleMsg(&logger, "eventId spark ", eventIndex);
 	if (engine->ignitionEvents.isReady) {
 		for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
 			IgnitionEvent *event = &engine->ignitionEvents.elements[i];

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -19,12 +19,6 @@ static bool noFiringUntilVvtSync(vvt_mode_e vvtMode) {
 		return true;
 	}
 
-	// Odd cylinder count engines don't work properly with wasted spark, so wait for full sync (so that sequential works)
-	// See https://github.com/rusefi/rusefi/issues/4195 for the issue to properly support this case
-	if (engineConfiguration->cylindersCount > 1 && engineConfiguration->cylindersCount % 2 == 1) {
-		return true;
-	}
-
 	// Symmetrical crank modes require cam sync before firing
 	// non-symmetrical cranks can use faster spin-up mode (firing in wasted/batch before VVT sync)
 	// Examples include Nissan MR/VQ, Miata NB, etc

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -386,8 +386,7 @@ ignition_mode_e getCurrentIgnitionMode() {
 	ignition_mode_e ignitionMode = engineConfiguration->ignitionMode;
 #if EFI_SHAFT_POSITION_INPUT
 	// In spin-up cranking mode we don't have full phase sync info yet, so wasted spark mode is better
-	// However, only do this on even cylinder count engines: odd cyl count doesn't fire at all
-	if (ignitionMode == IM_INDIVIDUAL_COILS && (engineConfiguration->cylindersCount % 2 == 0)) {
+	if (ignitionMode == IM_INDIVIDUAL_COILS) {
 		bool missingPhaseInfoForSequential = 
 			!engine->triggerCentral.triggerState.hasSynchronizedPhase();
 

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -404,7 +404,20 @@ ignition_mode_e getCurrentIgnitionMode() {
  * This heavy method is only invoked in case of a configuration change or initialization.
  */
 void prepareOutputSignals() {
-	getEngineState()->engineCycle = getEngineCycle(getEngineRotationState()->getOperationMode());
+	auto operationMode = getEngineRotationState()->getOperationMode();
+	getEngineState()->engineCycle = getEngineCycle(operationMode);
+
+	bool isOddFire = false;
+	for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
+		if (engineConfiguration->timing_offset_cylinder[i] != 0) {
+			isOddFire = true;
+			break;
+		}
+	}
+
+	// Use odd fire wasted spark logic if not two stroke, and an odd fire or odd cylinder # engine
+	getEngineState()->useOddFireWastedSpark = operationMode != TWO_STROKE
+								&& (isOddFire | (engineConfiguration->cylindersCount % 2 == 1));
 
 #if EFI_UNIT_TEST
 	if (verboseMode) {

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -193,6 +193,7 @@ TEST(ignition, oddCylinderWastedSpark) {
 	// dwell should start at 15 degrees ATDC and firing at 25 deg ATDC
 	engine->ignitionState.dwellAngle = 10;
 	engine->engineState.timingAdvance[0] = -25;
+	engine->engineState.useOddFireWastedSpark = true;
 	engineConfiguration->minimumIgnitionTiming = -25;
 
 	// expect to schedule the on-phase dwell and spark (not the wasted spark copy)

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -9,6 +9,8 @@
 #include "spark_logic.h"
 
 using ::testing::_;
+using ::testing::InSequence;
+using ::testing::StrictMock;
 
 TEST(ignition, twoCoils) {
 	EngineTestHelper eth(engine_type_e::FRANKENSO_BMW_M73_F);
@@ -147,4 +149,55 @@ TEST(ignition, CylinderTimingTrim) {
 	EXPECT_NEAR(engine->engineState.timingAdvance[1], unadjusted - 2, EPS4D);
 	EXPECT_NEAR(engine->engineState.timingAdvance[2], unadjusted + 2, EPS4D);
 	EXPECT_NEAR(engine->engineState.timingAdvance[3], unadjusted + 4, EPS4D);
+}
+
+TEST(ignition, oddCylinderWastedSpark) {
+	StrictMock<MockExecutor> mockExec;
+
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engine->scheduler.setMockExecutor(&mockExec);
+	engineConfiguration->cylindersCount = 1;
+	engineConfiguration->firingOrder = FO_1;
+	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
+
+	efitick_t nowNt1 = 1000000;
+	efitick_t nowNt2 = 2222222;
+
+
+	engine->rpmCalculator.oneDegreeUs = 100;
+
+	{
+		InSequence is;
+
+		// Should schedule one dwell+fire pair:
+		// Dwell 5 deg from now
+		float nt1deg = USF2NT(engine->rpmCalculator.oneDegreeUs);
+		efitick_t startTime = nowNt1 + nt1deg * 5;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		// Spark 15 deg from now
+		efitick_t endTime = startTime + nt1deg * 10;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+
+
+		// Should schedule second dwell+fire pair, the out of phase copy
+		// Dwell 5 deg from now
+		startTime = nowNt2 + nt1deg * 5;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		// Spark 15 deg from now
+		endTime = startTime + nt1deg * 10;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+	}
+
+	engine->ignitionState.sparkDwell = 1;
+
+	// dwell should start at 15 degrees ATDC and firing at 25 deg ATDC
+	engine->ignitionState.dwellAngle = 10;
+	engine->engineState.timingAdvance[0] = -25;
+	engineConfiguration->minimumIgnitionTiming = -25;
+
+	// expect to schedule the on-phase dwell and spark (not the wasted spark copy)
+	onTriggerEventSparkLogic(1200, nowNt1, 10, 30);
+
+	// expect to schedule second events, the out-of-phase dwell and spark (the wasted spark copy)
+	onTriggerEventSparkLogic(1200, nowNt2, 360 + 10, 360 + 30);
 }


### PR DESCRIPTION
support wasted spark on odd cylinder count engines, including during startup before the cam position is resolved.

5 cylinder firing wasted spark (every cylinder fires every 360 degrees):

![image](https://github.com/user-attachments/assets/630adba6-21cf-4dd0-a354-4e7e4c4eec10)

https://github.com/rusefi/rusefi/issues/4195 and also https://github.com/rusefi/rusefi/issues/6662

Also supports odd-fire but even-cylinder engines, as that's the same fundamental problem!

https://github.com/rusefi/rusefi/issues/6868

Here's an odd-fire 2 cyl running in wasted spark:

![image](https://github.com/user-attachments/assets/3c22fd22-1f2d-46a5-885a-05f42ad89f8e)

