### PR TITLE
Consoldate Tunerstudio panels

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3904,7 +3904,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Fixed cranking advance",	crankingTimingAngle, {useSeparateAdvanceForCranking == 0}
 		field = "Fixed Cranking Dwell",						ignitionDwellForCrankingMs
 
-	dialog = postCrankingEnrichmentText, "After start enrichment"
+	dialog = postCrankingEnrichmentText, ""
 		field = "After start enrichment mode",		postCrankingFuelUseTable
 		field = "Post-Cranking factor",				postCrankingFactor, {postCrankingFuelUseTable == 0}
 		field = "Duration",							postCrankingDurationSec, {postCrankingFuelUseTable == 0}
@@ -3931,7 +3931,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = crankingIAC
 		panel = crankingAdv
 
-	dialog = crankingDialog, "Cranking Settings",xAxis
+	dialog = crankingDialog, "", xAxis
 		panel = crankingDialogLeft
 		panel = primingFuelPulsePanel
 
@@ -3960,7 +3960,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = tpsTpsAccelTbl
 		panel = tpsTspRpmCorrection
 
-	dialog = AccelEnrich,	"Accel/Decel Enrichment", border
+	dialog = AccelEnrich,	"", border
 		panel = AccelEnrichText, West
 		panel = TpsTpsAeTables, Center
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1770,8 +1770,6 @@ menuDialog = main
 
 		# Accel enrichment
 		subMenu = AccelEnrich,				"Acceleration enrichment", 0, {isInjectionEnabled}
-		subMenu = tpsTpsAccelTbl,			"TPS/TPS acceleration extra fuel", 0, {isInjectionEnabled}
-		subMenu = tpsTspRpmCorrection,      "TPS/TPS AE RPM correction", 0, {isInjectionEnabled}
 
 		groupMenu = "Wall wetting AE"
 		groupChildMenu = wwTauCurves, "Evap time", 0, { complexWallModel != 0 }
@@ -3913,8 +3911,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Post-Cranking factor",				postCrankingFactor, {postCrankingFuelUseTable == 0}
 		field = "Duration",							postCrankingDurationSec, {postCrankingFuelUseTable == 0}
 
-	dialog = postCrankingEnrichment, "After start enrichment", yAxis
-		panel = postCrankingEnrichmentText
+	dialog = postCrankingEnrichment, "After start enrichment", border
+		panel = postCrankingEnrichmentText, North
 		panel = postCrankingEnrichmentTable, 0, {postCrankingFuelUseTable}
 
 	dialog = primingFuelPulsePanel, "Priming fuel pulse"
@@ -3952,9 +3950,17 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 
 ;			Tuning->AccelEnrichment
-	dialog = AccelEnrich,	"Accel/Decel Enrichment"
+	dialog = AccelEnrichText ""
 		panel = TpsAccelPanel
 		panel = WallWettingAccelPanel
+
+	dialog = TpsTpsAeTables,	"TPS Acceleration Enrichment"
+		panel = tpsTpsAccelTbl
+		panel = tpsTspRpmCorrection
+
+	dialog = AccelEnrich,	"Accel/Decel Enrichment", border
+		panel = AccelEnrichText, West
+		panel = TpsTpsAeTables, Center
 
 	dialog = wwTauCurves, "Wall wetting AE evaporation time"
 		field = "#Set a base evaporation time based on coolant temperature, and a multiplier based on MAP."

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1761,7 +1761,6 @@ menuDialog = main
 		subMenu = iatFuelCorrCurve,			"IAT multiplier", 0, {isInjectionEnabled}
 		subMenu = fuelClosedLoopDialog,	"Closed loop fuel correction", 0, {isInjectionEnabled}
 		subMenu = coastingFuelCutControl,	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled}
-		subMenu = dfcoMapRpmCorrection,	"DFCO MAP to RPM threshold", 0, {isInjectionEnabled && useTableForDfcoMap }
 		subMenu = std_separator
 
 		# Injector model
@@ -1817,7 +1816,6 @@ menuDialog = main
 	menu = "&Cranking"
 		subMenu = crankingDialog,			"Cranking settings"
 		subMenu = postCrankingEnrichment,	"After-start enrichment"
-		subMenu = primingFuelPulsePanel,	"Priming pulse"
 		subMenu = std_separator
 
 		subMenu = crankingCltCurve,			"Fuel CLT multiplier"
@@ -3926,12 +3924,16 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Use Flex Fuel cranking table",			flexCranking, { flexSensorPin != @@ADC_CHANNEL_NONE@@ }
 
 ;			Cranking->Cranking Settings
-	dialog = crankingDialog, "Cranking Settings"
+	dialog = crankingDialogLeft, "Cranking Settings"
 		field = "Cranking RPM limit",						cranking_rpm
 		panel = crankingFuel
 		panel = crankingIgnition
 		panel = crankingIAC
 		panel = crankingAdv
+
+	dialog = crankingDialog, "Cranking Settings",xAxis
+		panel = crankingDialogLeft
+		panel = primingFuelPulsePanel
 
 	dialog = TpsAccelPanel, "TPS"
 		field = "Set 'Debug Mode' to see detailed 'TPS acceleration enrichment' diagnostics"
@@ -4497,10 +4499,11 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Vehicle speed cut above",		coastingFuelCutVssHigh, {coastingFuelCutEnabled}
 		field = "Vehicle speed restore below",	coastingFuelCutVssLow, {coastingFuelCutEnabled}
 		field = "Cut fuel below TPS",			coastingFuelCutTps, {coastingFuelCutEnabled}
-		field = "Cut fuel below MAP mode",		useTableForDfcoMap, {coastingFuelCutEnabled}
-		field = "Cut fuel below MAP",		coastingFuelCutMap, {coastingFuelCutEnabled  && !useTableForDfcoMap}
 		field = "Fuel cut delay", dfcoDelay, {coastingFuelCutEnabled}
 		field = "Inhibit closed loop fuel after cut", noFuelTrimAfterDfcoTime, {coastingFuelCutEnabled}
+		field = "Cut fuel below MAP mode",		useTableForDfcoMap, {coastingFuelCutEnabled}
+		field = "Cut fuel below MAP",		coastingFuelCutMap, {coastingFuelCutEnabled  && !useTableForDfcoMap}
+		panel = dfcoMapRpmCorrection, {coastingFuelCutEnabled  && useTableForDfcoMap}
 
 	dialog = rotaryDialog, "Rotary"
 		field = "Enable Trailing Sparks", enableTrailingSparks

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1234,7 +1234,7 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		yBins	= hpfpCompensationLoadBins, running_fuel
 		zBins	= hpfpCompensation
 
-	table = postCrankingEnrichmentTable, postCrankingEnrichmentTableId, "", 1
+	table = postCrankingEnrichmentTable, postCrankingEnrichmentTableId, "Enrichment Multiplier Table", 1
 		xBins = postCrankingEnrichRuntimeBins, running_timeSinceCrankingInSecs
 		yBins = postCrankingEnrichTempBins, coolant
 		zBins = postCrankingEnrichTable
@@ -1819,7 +1819,6 @@ menuDialog = main
 	menu = "&Cranking"
 		subMenu = crankingDialog,			"Cranking settings"
 		subMenu = postCrankingEnrichment,	"After-start enrichment"
-		subMenu = postCrankingEnrichmentTable, "After-start enrichment table", 0, {postCrankingFuelUseTable}
 		subMenu = primingFuelPulsePanel,	"Priming pulse"
 		subMenu = std_separator
 
@@ -3909,10 +3908,14 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Fixed cranking advance",	crankingTimingAngle, {useSeparateAdvanceForCranking == 0}
 		field = "Fixed Cranking Dwell",						ignitionDwellForCrankingMs
 
-	dialog = postCrankingEnrichment, "After start enrichment"
+	dialog = postCrankingEnrichmentText, "After start enrichment"
 		field = "After start enrichment mode",		postCrankingFuelUseTable
 		field = "Post-Cranking factor",				postCrankingFactor, {postCrankingFuelUseTable == 0}
 		field = "Duration",							postCrankingDurationSec, {postCrankingFuelUseTable == 0}
+
+	dialog = postCrankingEnrichment, "After start enrichment", yAxis
+		panel = postCrankingEnrichmentText
+		panel = postCrankingEnrichmentTable, 0, {postCrankingFuelUseTable}
 
 	dialog = primingFuelPulsePanel, "Priming fuel pulse"
 		field = "Priming delay",	primingDelay


### PR DESCRIPTION
The dropdown submenus are getting long with the recently added features, any opposition to combining related tables and settings?

Menus affected in this PR:
- After start enrichment
- cranking+priming pulse
- accel enrichment + tps/tps tables
- dfco

![ts-panels-2](https://github.com/user-attachments/assets/623c4603-902b-41b7-a0c8-7c629f3b758b)
