### PR TITLE
Reorganize Idle Settings

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1834,11 +1834,11 @@ menuDialog = main
 		subMenu = cltCrankingTaperDurationCurve,			"Cranking taper duration multiplier", 0, {useCrankingIdleTaperTableSetting}
 
 	menu = "&Idle" @@if_ts_show_idle
+		subMenu = cltIdleRPMCurve,			"Target RPM" @@if_ts_show_idle
 		subMenu = idleSettingsOpen,				"Open Loop Idle" @@if_ts_show_idle
-		subMenu = idleSettingsClosed,				"Closed Loop Idle" { idleMode == @@idle_mode_e_IM_AUTO@@ } @@if_ts_show_idle
+		subMenu = idleSettingsClosed,			"Closed Loop Idle"  @@if_ts_show_idle
 		subMenu = idlehw,					"Idle hardware" @@if_ts_show_idle
 		subMenu = std_separator @@if_ts_show_idle
-		subMenu = idleTimingPidCorrDialog,	"Closed-loop idle timing" @@if_ts_show_idle
 		subMenu = iacPidMultTbl,			"IAC PID multiplier", 0, {idleMode == 0 && useIacPidMultTable} @@if_ts_show_idle
 		subMenu = iacCoastingCurve,			"Coasting IAC position", 0, {useIacTableForCoasting} @@if_ts_show_idle
 		subMenu = std_separator @@if_ts_show_idle
@@ -3343,19 +3343,20 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Electronic throttle idle range",			etbIdleThrottleRange
 		panel = idleHwType
 
-	dialog = idlePidSettings, "Closed Loop Idle"
-		field = "RPM deadzone",	idlePidRpmDeadZone
-		field = "P-factor",								idleRpmPid_pFactor
-		field = "I-factor",								idleRpmPid_iFactor
-		field = "derivativeFilterLoss",					idle_derivativeFilterLoss
-		field = "antiwindupFreq",						idle_antiwindupFreq
-		field = "D-factor",								idleRpmPid_dFactor
-		field = "Min",									idleRpmPid_minValue
-		field = "Max",									idleRpmPid_maxValue
-		field = "iTerm Min",							idlerpmpid_iTermMin
-		field = "iTerm Max",							idlerpmpid_iTermMax
-		field = "PID Extra for low RPM",				pidExtraForLowRpm
-		field = "Use IAC PID Multiplier Table",			useIacPidMultTable
+	dialog = idlePidSettings, "IAC Position"
+		field = "Idle control mode",					idleMode
+		field = "RPM deadzone",							idlePidRpmDeadZone { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "P-factor",								idleRpmPid_pFactor { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "I-factor",								idleRpmPid_iFactor { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "derivativeFilterLoss",					idle_derivativeFilterLoss { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "antiwindupFreq",						idle_antiwindupFreq { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "D-factor",								idleRpmPid_dFactor { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "Min",									idleRpmPid_minValue { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "Max",									idleRpmPid_maxValue { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "iTerm Min",							idlerpmpid_iTermMin { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "iTerm Max",							idlerpmpid_iTermMax { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "PID Extra for low RPM",				pidExtraForLowRpm { idleMode == @@idle_mode_e_IM_AUTO@@ }
+		field = "Use IAC PID Multiplier Table",			useIacPidMultTable { idleMode == @@idle_mode_e_IM_AUTO@@ }
 
 	dialog = idleOpenLoop, "Open Loop Idle"
 		slider = "Open loop base position",				manIdlePosition, horizontal
@@ -3378,7 +3379,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Use coasting idle table",	useIacTableForCoasting
 
 	dialog = idleSettingsLeft, "", yAxis
-		field = "Idle control mode",					idleMode
 		field = "! Solenoid idle control is disabled at zero RPM"
 ; gating applies both to open loop and closed loop!
 		panel = idleGating
@@ -3390,12 +3390,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = idleSettingsLeft
 		panel = cltIdleCurve
 
-	dialog = idleSettingsClosed, "", xAxis
-		panel = idlePidSettings
-		panel = cltIdleRPMCurve
-
-	dialog = idleTimingPidCorrDialog, "", yAxis
-		field = ""
+	dialog = idleTimingPidCorrDialog, "Ignition Timing", yAxis
 		field = "Enable closed loop idle ignition timing",	useIdleTimingPidControl
 		field = ""
 		field = "#Gain is in degrees advance per rpm away from target"
@@ -3405,8 +3400,11 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = ""
 		field = "Min adjustment (retard)",								idleTimingPid_minValue, {useIdleTimingPidControl}
 		field = "Max adjustment (advance)",								idleTimingPid_maxValue, {useIdleTimingPidControl}
-		field = ""
 		field = "#Use debug mode 'Timing' to view idle timing adjustment"
+
+	dialog = idleSettingsClosed, "", xAxis
+		panel = idlePidSettings
+		panel = idleTimingPidCorrDialog
 
 ;			Engine->Fan Settings
 	dialog = fan1Settings, "Fan 1"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1834,11 +1834,9 @@ menuDialog = main
 		subMenu = cltCrankingTaperDurationCurve,			"Cranking taper duration multiplier", 0, {useCrankingIdleTaperTableSetting}
 
 	menu = "&Idle" @@if_ts_show_idle
-		subMenu = idleSettings,				"Idle settings" @@if_ts_show_idle
+		subMenu = idleSettingsOpen,				"Open Loop Idle" @@if_ts_show_idle
+		subMenu = idleSettingsClosed,				"Closed Loop Idle" { idleMode == @@idle_mode_e_IM_AUTO@@ } @@if_ts_show_idle
 		subMenu = idlehw,					"Idle hardware" @@if_ts_show_idle
-		subMenu = std_separator @@if_ts_show_idle
-		subMenu = cltIdleRPMCurve,			"Target RPM" @@if_ts_show_idle
-		subMenu = cltIdleCurve,				"CLT multiplier" @@if_ts_show_idle
 		subMenu = std_separator @@if_ts_show_idle
 		subMenu = idleTimingPidCorrDialog,	"Closed-loop idle timing" @@if_ts_show_idle
 		subMenu = iacPidMultTbl,			"IAC PID multiplier", 0, {idleMode == 0 && useIacPidMultTable} @@if_ts_show_idle
@@ -3346,6 +3344,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = idleHwType
 
 	dialog = idlePidSettings, "Closed Loop Idle"
+		field = "RPM deadzone",	idlePidRpmDeadZone
 		field = "P-factor",								idleRpmPid_pFactor
 		field = "I-factor",								idleRpmPid_iFactor
 		field = "derivativeFilterLoss",					idle_derivativeFilterLoss
@@ -3369,7 +3368,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	dialog = idleGating, "Idle Detection Thresholds"
 		field = "TPS threshold",	idlePidDeactivationTpsThreshold
 		field = "RPM upper limit",	idlePidRpmUpperLimit
-		field = "RPM deadzone",	idlePidRpmDeadZone
 		field = "Max vehicle speed", maxIdleVss
 
 	dialog = idleExtra, "Extra Idle Features"
@@ -3379,17 +3377,22 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Use idle tables for cranking taper",		useSeparateIdleTablesForCrankingTaper
 		field = "Use coasting idle table",	useIacTableForCoasting
 
-	dialog = idleSettings, "", yAxis
+	dialog = idleSettingsLeft, "", yAxis
 		field = "Idle control mode",					idleMode
-
 		field = "! Solenoid idle control is disabled at zero RPM"
-
 ; gating applies both to open loop and closed loop!
 		panel = idleGating
 ; closed loop mode is an addition on top of open loop, so idleOpenLoop stays open even when closed loop is selected
 		panel = idleOpenLoop
-		panel = idlePidSettings, { idleMode == @@idle_mode_e_IM_AUTO@@ }
 		panel = idleExtra
+
+	dialog = idleSettingsOpen, "", xAxis
+		panel = idleSettingsLeft
+		panel = cltIdleCurve
+
+	dialog = idleSettingsClosed, "", xAxis
+		panel = idlePidSettings
+		panel = cltIdleRPMCurve
 
 	dialog = idleTimingPidCorrDialog, "", yAxis
 		field = ""


### PR DESCRIPTION
The current idle settings menu is too tall to fit on a 1300x700 display, and is cumbersome to work with as a result

I've reorganized it into open loop and closed loop menus:
- open loop only contains settings relevant to open loop IAC position, includeing the CLT multiplier curve
- closed loop contains both IAC and ignition settings
    - it might be nice to include live data of PID adders, current IAC position, and timing here, but that may get too crowded

![idle menu](https://github.com/user-attachments/assets/5c0a14f2-3849-4d0a-bef8-6f0f1c48054d)
