### PR TITLE
na miata CAS as cam trigger

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -71,6 +71,8 @@ trigger_type_e getVvtTriggerType(vvt_mode_e vvtMode) {
 		return trigger_type_e::TT_VVT_TOYOTA_3_TOOTH;
 	case VVT_MIATA_NB:
 		return trigger_type_e::TT_VVT_MIATA_NB;
+	case VVT_MIATA_NA:
+		return trigger_type_e::TT_VVT_MIATA_NA;
 	case VVT_BOSCH_QUICK_START:
 		return trigger_type_e::TT_VVT_BOSCH_QUICK_START;
 	case VVT_HONDA_K_EXHAUST:

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -491,13 +491,16 @@ enum class trigger_type_e : uint32_t {
 
 	TT_VVT_MAZDA_L = 75,
 
+	TT_VVT_MIATA_NA = 76,
+
+
 	// do not forget to edit "#define trigger_type_e_enum" line in integration/rusefi_config.txt file to propogate new value to rusefi.ini TS project
 	// do not forget to invoke "gen_config.bat" once you make changes to integration/rusefi_config.txt
 	// todo: one day a hero would integrate some of these things into Makefile in order to reduce manual magic
 	//
 	// Another point: once you add a new trigger, run get_trigger_images.bat which would run fome_test.exe from unit_tests
 	//
-	TT_UNUSED = 76, // this is used if we want to iterate over all trigger types
+	TT_UNUSED = 77, // this is used if we want to iterate over all trigger types
 };
 
 typedef enum {

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -59,6 +59,7 @@ typedef enum  __attribute__ ((__packed__)) {
 	 */
 	VVT_MIATA_NB = 3,
 
+	VVT_MIATA_NA = 4,
 	/**
 	 * @see TT_VVT_BOSCH_QUICK_START
 	 */

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -187,6 +187,24 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 	s->addEvent720(720, true, TriggerWheel::T_PRIMARY);
 }
 
+void initializeMazdaMiataNaCamShape(TriggerWaveform *s) {
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
+
+	// nominal gap is 0.325
+	s->setTriggerSynchronizationGap2(0.1, 0.5);
+	// nominal gap is ~1.52
+	s->setSecondTriggerSynchronizationGap2(0.5, 2.3);
+
+	/**
+	 * http://rusefi.com/forum/viewtopic.php?f=3&t=729&p=12983#p12983
+	 */
+	s->addEvent720(216.897031, true, TriggerWheel::T_PRIMARY);
+	s->addEvent720(288.819688, false, TriggerWheel::T_PRIMARY);		// <-- This edge is the sync point
+
+	s->addEvent720(577.035495, true, TriggerWheel::T_PRIMARY);
+	s->addEvent720(720.0f, false, TriggerWheel::T_PRIMARY);
+}
+
 // https://rusefi.com/forum/viewtopic.php?f=17&t=2417
 // Cam pattern for intake/exhaust on all Skyactiv-G (and maybe -D/-X)
 void initializeMazdaSkyactivCam(TriggerWaveform *s) {

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -188,12 +188,10 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 }
 
 void initializeMazdaMiataNaCamShape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Both);
 
-	// nominal gap is 0.325
-	s->setTriggerSynchronizationGap2(0.1, 0.5);
-	// nominal gap is ~1.52
-	s->setSecondTriggerSynchronizationGap2(0.5, 2.3);
+	s->setTriggerSynchronizationGap3(0, 0.1, 0.5);
+	s->setTriggerSynchronizationGap3(1, 0.5, 2.3);
 
 	/**
 	 * http://rusefi.com/forum/viewtopic.php?f=3&t=729&p=12983#p12983

--- a/firmware/controllers/trigger/decoders/trigger_mazda.h
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.h
@@ -23,6 +23,7 @@ void configureMazdaProtegeLx(TriggerWaveform *s);
  * same decoder is used for VVT processing
  */
 void initializeMazdaMiataVVtCamShape(TriggerWaveform *s);
+void initializeMazdaMiataNaCamShape(TriggerWaveform *s);
 
 void initializeMazdaSkyactivCam(TriggerWaveform *s);
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -434,6 +434,10 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		initializeMazdaMiataVVtCamShape(this);
 		break;
 
+	case trigger_type_e::TT_VVT_MIATA_NA:
+		initializeMazdaMiataNaCamShape(this);
+		break;
+
 	case trigger_type_e::TT_RENIX_66_2_2_2:
 		initializeRenix66_2_2(this);
 		break;

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -176,6 +176,7 @@ static angle_t adjustCrankPhase(int camIndex) {
 	case VVT_NISSAN_VQ:
 	case VVT_BOSCH_QUICK_START:
 	case VVT_MIATA_NB:
+	case VVT_MIATA_NA:
 	case VVT_TOYOTA_3_TOOTH:
 	case VVT_TOYOTA_4_1:
 	case VVT_FORD_ST170:

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -267,7 +267,7 @@ end_struct
 #define debug_mode_e_enum "INVALID", "TPS acceleration enrichment", "INVALID", "Stepper Idle Control", "Engine Load accl enrich", "Trigger Counters", "Soft Spark Cut", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "SD card", "sr5", "Knock", "INVALID", "Electronic Throttle", "Executor", "Bench Test / TS commands", "INVALID", "Analog inputs #1", "INSTANT_RPM", "INVALID", "Status", "INVALID", "INVALID", "MAP", "Metrics", "INVALID", "Ion Sense", "TLE8888", "Analog inputs #2", "Dwell Metric", "INVALID", "INVALID", "Boost Control", "INVALID", "INVALID", "ETB Autotune", "Composite Log", "INVALID", "INVALID", "INVALID", "Dyno_View", "Logic_Analyzer", "INVALID", "TCU", "Lua"
 custom debug_mode_e 1 bits, U08, @OFFSET@, [0:5], @@debug_mode_e_enum@@
 
-#define vvt_mode_e_enum "Inactive", "Single Tooth", "Toyota 3 Tooth", "Miata NB2", "INVALID", "Bosch Quick Start", "4/1", "ST 170", "Ford Barra 3+1", "Nissan VQ", "Honda K Intake", "Nissan MR18", "Mitsu 3A92", "VTwin by MAP", "Mitsu 6G75", "Mazda Skyactiv", "Honda K Exhaust", "Mitsubishi 4G92/93/94", "Mitsubishi 4G63", "Mazda L"
+#define vvt_mode_e_enum "Inactive", "Single Tooth", "Toyota 3 Tooth", "Miata NB2", "Miata NA", "Bosch Quick Start", "4/1", "ST 170", "Ford Barra 3+1", "Nissan VQ", "Honda K Intake", "Nissan MR18", "Mitsu 3A92", "VTwin by MAP", "Mitsu 6G75", "Mazda Skyactiv", "Honda K Exhaust", "Mitsubishi 4G92/93/94", "Mitsubishi 4G63", "Mazda L"
 custom vvt_mode_e 1 bits, U08, @OFFSET@, [0:5], @@vvt_mode_e_enum@@
 
 ! At the moment TIM1, TIM2, TIM3 and TIM9 are configured as ICU
@@ -1464,7 +1464,7 @@ engine_configuration_s engineConfiguration;
 	uint16_t[DWELL_CURVE_SIZE] autoscale sparkDwellValues;;"ms", 0.01, 0, 0, 30, 2
 
 	int8_t[CLT_CURVE_SIZE] autoscale cltIdleRpmBins;CLT-based target RPM for automatic idle controller;"C", 2, 0, -40, 200, 0
-	uint8_t[CLT_CURVE_SIZE] autoscale cltIdleRpm;See idleRpmPid;"RPM", 20, 0, 0, 5000, 0
+	uint8_t[CLT_CURVE_SIZE] autoscale cltIdleRpm;RPM target used for closed loop idle control;"RPM", 20, 0, 0, 5000, 0
 	float[CLT_TIMING_CURVE_SIZE] cltTimingBins;CLT-based timing correction;"C", 1, 0, -100, 250, 1
 	float[CLT_TIMING_CURVE_SIZE] cltTimingExtra;;"degree", 1, 0, -400, 400, 0
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1464,7 +1464,7 @@ engine_configuration_s engineConfiguration;
 	uint16_t[DWELL_CURVE_SIZE] autoscale sparkDwellValues;;"ms", 0.01, 0, 0, 30, 2
 
 	int8_t[CLT_CURVE_SIZE] autoscale cltIdleRpmBins;CLT-based target RPM for automatic idle controller;"C", 2, 0, -40, 200, 0
-	uint8_t[CLT_CURVE_SIZE] autoscale cltIdleRpm;RPM target used for closed loop idle control;"RPM", 20, 0, 0, 5000, 0
+	uint8_t[CLT_CURVE_SIZE] autoscale cltIdleRpm;See idleRpmPid;"RPM", 20, 0, 0, 5000, 0
 	float[CLT_TIMING_CURVE_SIZE] cltTimingBins;CLT-based timing correction;"C", 1, 0, -100, 250, 1
 	float[CLT_TIMING_CURVE_SIZE] cltTimingExtra;;"degree", 1, 0, -400, 400, 0
 


### PR DESCRIPTION
Allow using an NA Miata CAS as a cam sensor, rather than primary trigger. Suppose you've added a 36-1 to the crank, but want to keep the CAS to resolve full sequential operation.