### PR TITLE
Fix dynamic labels for GPPWM tables

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -540,7 +540,7 @@ typedef enum __attribute__ ((__packed__)) {
 	GPPWM_AuxLinear3 = 29,
 	GPPWM_AuxLinear4 = 30,
 	GPPWM_VehicleSpeed = 31,
-} gppwm_channel_e;
+} gppwm_channel_e; // TODO Keep pwmAxisLabels in tunerstudio.template.ini in sync when adding additional options to this enum
 
 typedef enum __attribute__ ((__packed__)) {
 	B50KBPS = 0, // 50kbps

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -190,6 +190,7 @@ enable2ndByteCanID = false
 	wbo0_hasFault = { enableAemXSeries && (faultCode >= 3) }
 
 [PcVariables]
+	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "INVALID", "INVALID", "INVALID"
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
 	wueAfrTargetOffset = array, S16, [ 16], ":1",	0.1, 0.0, -3.0, 3.0, 1;
@@ -824,6 +825,7 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		zBins		= tpsTpsAccelTable
 
 		table = boostTableTbl,  boostMapOpen,  "Boost control duty cycle (open loop)",	1
+		xyLabels	= "RPMValue", {bitStringValue(pwmAxisLabels, boostOpenLoopYAxis)}
 		xBins		= boostRpmBins,  RPMValue
 		yBins		= boostTpsBins,  TPSValue
 		zBins		= boostTableOpenLoop
@@ -1186,25 +1188,25 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		upDownLabel = "(Later)", "(Sooner)"
 
 	table = gppwm1Tbl, gppwm1Map, "GP#1", 1
-		xyLabels = "RPM", ""
+		xyLabels = {bitStringValue(pwmAxisLabels, gppwm1_rpmAxis)}, {bitStringValue(pwmAxisLabels, gppwm1_loadAxis)}
 		xBins = gppwm1_rpmBins, gppwmXAxis1
 		yBins = gppwm1_loadBins, gppwmYAxis1
 		zBins = gppwm1_table
 
 	table = gppwm2Tbl, gppwm2Map, "GP#2", 1
-		xyLabels = "RPM", ""
+		xyLabels = {bitStringValue(pwmAxisLabels, gppwm2_rpmAxis)}, {bitStringValue(pwmAxisLabels, gppwm2_loadAxis)}
 		xBins = gppwm2_rpmBins, gppwmXAxis2
 		yBins = gppwm2_loadBins, gppwmYAxis2
 		zBins = gppwm2_table
 
 	table = gppwm3Tbl, gppwm3Map, "GP#3", 1
-		xyLabels = "RPM", ""
+    	xyLabels = {bitStringValue(pwmAxisLabels, gppwm3_rpmAxis)}, {bitStringValue(pwmAxisLabels, gppwm3_loadAxis)}
 		xBins = gppwm3_rpmBins, gppwmXAxis3
 		yBins = gppwm3_loadBins, gppwmYAxis3
 		zBins = gppwm3_table
 
 	table = gppwm4Tbl, gppwm4Map, "GP#4", 1
-		xyLabels = "RPM", ""
+    	xyLabels = {bitStringValue(pwmAxisLabels, gppwm4_rpmAxis)}, {bitStringValue(pwmAxisLabels, gppwm4_loadAxis)}
 		xBins = gppwm4_rpmBins, gppwmXAxis4
 		yBins = gppwm4_loadBins, gppwmYAxis4
 		zBins = gppwm4_table

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -190,7 +190,7 @@ enable2ndByteCanID = false
 	wbo0_hasFault = { enableAemXSeries && (faultCode >= 3) }
 
 [PcVariables]
-	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "INVALID", "INVALID", "INVALID"
+	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3 *", "Aux Linear 4 *", "Vehicle Speed KPH"
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
 	wueAfrTargetOffset = array, S16, [ 16], ":1",	0.1, 0.0, -3.0, 3.0, 1;

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -190,7 +190,7 @@ enable2ndByteCanID = false
 	wbo0_hasFault = { enableAemXSeries && (faultCode >= 3) }
 
 [PcVariables]
-	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3 *", "Aux Linear 4 *", "Vehicle Speed KPH"
+	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1", "Aux Linear 2", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3", "Aux Linear 4", "Vehicle Speed KPH"
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
 	wueAfrTargetOffset = array, S16, [ 16], ":1",	0.1, 0.0, -3.0, 3.0, 1;


### PR DESCRIPTION
This allows the GPPWM tables to change the axis name dynamically.