### PR TITLE
CEL workaround

### DIFF
--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -9,6 +9,8 @@
 
 #include "backup_ram.h"
 
+#include "malfunction_central.h"
+
 static critical_msg_t warningBuffer;
 static critical_msg_t criticalErrorMessageBuffer;
 
@@ -228,6 +230,7 @@ void firmwareError(ObdCode code, const char *fmt, ...) {
 	palWritePad(criticalErrorLedPort, criticalErrorLedPin, criticalErrorLedState);
 	turnAllPinsOff();
 	enginePins.communicationLedPin.setValue(1);
+	setError(true, code);
 
 	if (indexOf(fmt, '%') == -1) {
 		/**

--- a/firmware/controllers/gauges/malfunction_indicator.cpp
+++ b/firmware/controllers/gauges/malfunction_indicator.cpp
@@ -95,21 +95,11 @@ private:
 		static error_codes_set_s localErrorCopy;
 		// todo: why do I not see this on a real vehicle? is this whole blinking logic not used?
 		getErrorCodes(&localErrorCopy);
-		/* Remove the CEL blinking errors for now
+
 		for (int p = 0; p < localErrorCopy.count; p++) {
 			// Calculate how many digits in this integer and display error code from start to end
 			int code = (int)localErrorCopy.error_codes[p];
 			DisplayErrorCode(DigitLength(code), code);
-		}
-		*/
-		if (localErrorCopy.count > 0 && hasFirmwareErrorFlag) {
-			enginePins.checkEnginePin.setValue(1);
-			chThdSleepMilliseconds(100);
-			enginePins.checkEnginePin.setValue(0);
-		} else if (localErrorCopy.count > 0 && !hasFirmwareErrorFlag) {
-			enginePins.checkEnginePin.setValue(1);
-		} else {
-			enginePins.checkEnginePin.setValue(0);
 		}
 #endif // EFI_SHAFT_POSITION_INPUT
 	}

--- a/firmware/controllers/gauges/malfunction_indicator.cpp
+++ b/firmware/controllers/gauges/malfunction_indicator.cpp
@@ -95,11 +95,16 @@ private:
 		static error_codes_set_s localErrorCopy;
 		// todo: why do I not see this on a real vehicle? is this whole blinking logic not used?
 		getErrorCodes(&localErrorCopy);
+		/*
 		for (int p = 0; p < localErrorCopy.count; p++) {
 			// Calculate how many digits in this integer and display error code from start to end
 			int code = (int)localErrorCopy.error_codes[p];
 			DisplayErrorCode(DigitLength(code), code);
 		}
+		*/
+		if (localErrorCopy.count > 0) enginePins.checkEnginePin.setValue(1);
+		
+		else enginePins.checkEnginePin.setValue(0);
 #endif // EFI_SHAFT_POSITION_INPUT
 	}
 };

--- a/firmware/controllers/gauges/malfunction_indicator.cpp
+++ b/firmware/controllers/gauges/malfunction_indicator.cpp
@@ -95,16 +95,22 @@ private:
 		static error_codes_set_s localErrorCopy;
 		// todo: why do I not see this on a real vehicle? is this whole blinking logic not used?
 		getErrorCodes(&localErrorCopy);
-		/*
+		/* Remove the CEL blinking errors for now
 		for (int p = 0; p < localErrorCopy.count; p++) {
 			// Calculate how many digits in this integer and display error code from start to end
 			int code = (int)localErrorCopy.error_codes[p];
 			DisplayErrorCode(DigitLength(code), code);
 		}
 		*/
-		if (localErrorCopy.count > 0) enginePins.checkEnginePin.setValue(1);
-		
-		else enginePins.checkEnginePin.setValue(0);
+		if (localErrorCopy.count > 0 && hasFirmwareErrorFlag) {
+			enginePins.checkEnginePin.setValue(1);
+			chThdSleepMilliseconds(100);
+			enginePins.checkEnginePin.setValue(0);
+		} else if (localErrorCopy.count > 0 && !hasFirmwareErrorFlag) {
+			enginePins.checkEnginePin.setValue(1);
+		} else {
+			enginePins.checkEnginePin.setValue(0);
+		}
 #endif // EFI_SHAFT_POSITION_INPUT
 	}
 };

--- a/firmware/controllers/sensors/sensor_checker.cpp
+++ b/firmware/controllers/sensors/sensor_checker.cpp
@@ -122,8 +122,9 @@ static void check(SensorType type) {
 	if (code != ObdCode::None) {
 		warning(code, "Sensor fault: %s %s", Sensor::getSensorName(type), describeUnexpected(result.Code));
 		setError(true, code);
+	} else {
+		setError(false, code);
 	}
-	else setError(false, code);
 }
 
 #if BOARD_EXT_GPIOCHIPS > 0 && EFI_PROD_CODE
@@ -163,8 +164,7 @@ void SensorChecker::onSlowCallback() {
 			warning(ObdCode::Sensor5vSupplyLow, "5V sensor supply low: %.2f", sensorSupply);
 			setError(true, ObdCode::Sensor5vSupplyLow);
 			return;
-		}
-		else {
+		} else {
 			setError(false, ObdCode::Sensor5vSupplyHigh);
 			setError(false, ObdCode::Sensor5vSupplyLow);
 		}


### PR DESCRIPTION
Temporary make the CEL to turn on if the error counter is above 0 like most OEM applications instead of blinking.