### PR TITLE
upload-artifact@v4

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -327,13 +327,13 @@ jobs:
 
     # If not uploading the full bundle, at least upload the bin+ini so you can test off a PR
     - name: Upload build bin
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: fome_${{matrix.build-target}}.bin
         path: ./firmware/deliver/fome.bin
 
     - name: Upload ini
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.ini-file}}
         path: ./firmware/tunerstudio/generated/${{matrix.ini-file}}


### PR DESCRIPTION
https://github.com/FOME-Tech/fome-fw/actions/runs/12814534772/job/35731296820

>    Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
