### PR TITLE
Simulator: GCC 14 Wunused-result

### DIFF
--- a/misc/jenkins/compile_other_versions/compile.sh
+++ b/misc/jenkins/compile_other_versions/compile.sh
@@ -9,7 +9,7 @@ BOARD_DIR="$1"
 # for example 'proteus_f4'
 export BUNDLE_NAME="$2"
 
-SCRIPT_NAME=compile_and_upload.sh
+SCRIPT_NAME="compile.sh"
 echo "Entering $SCRIPT_NAME with folder $BOARD_DIR and bundle name $BUNDLE_NAME"
 
 [ -n $BOARD_DIR ] || { echo "BOARD_DIR parameter expected"; exit 1; }

--- a/simulator/simulator/can/hal_can_lld.cpp
+++ b/simulator/simulator/can/hal_can_lld.cpp
@@ -141,7 +141,7 @@ void can_lld_stop(CANDriver *canp) {
 	(void)canp;
 
 	// Remove from the "interrupt handler" list
-	std::remove(instances.begin(), instances.end(), canp);
+	(void)std::remove(instances.begin(), instances.end(), canp);
 
 	// Close the socket.
 	close(canp->sock);


### PR DESCRIPTION
GCC 14 is complaining about this syntax

```
simulator/can/hal_can_lld.cpp: In function ‘void can_lld_stop(CANDriver*)’:
simulator/can/hal_can_lld.cpp:144:20: error: ignoring return value of ‘constexpr _FIter std::remove(_FIter, _FIter, const _Tp&) [with _FIter = __gnu_cxx::__normal_iterator<CANDriver**, vector<CANDriver*> >; _Tp = CANDriver*]’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
  144 |         std::remove(instances.begin(), instances.end(), canp);
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

----

https://stackoverflow.com/a/53581957