### PR TITLE
correct Fuel target gauge names

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1477,8 +1477,8 @@ gaugeCategory = Fueling
 	fuelingLoadGauge = fuelingLoad, @@GAUGE_NAME_FUEL_LOAD@@, "%", 0, 300, 0, 0, 300, 300, 1, 1
 	totalFuelConsumptionGauge = totalFuelConsumption, @@GAUGE_NAME_FUEL_CONSUMPTION@@, "g", 0, 10000, 0, 0, 10000, 10000, 0, 0
 	fuelFlowRateGauge = fuelFlowRate, @@GAUGE_NAME_FUEL_FLOW@@, "g/s", 0, 50, 0, 0, 50, 50, 2, 0
-	targetLambdaGauge = targetLambda,"fuel: target lambda", "",		10,	19.4,		12,	13,		15,	16,	2,	2
-	currentTargetAfrGauge = targetAFR,"fuel: target AFR", "",		0.65,	1.2,		0.7,	0.75,		1.1,	1.15,	3,	2
+	targetLambdaGauge = targetLambda,"Fuel: target lambda", "",		10,	19.4,		12,	13,		15,	16,	2,	2
+	currentTargetAfrGauge = targetAFR,"Fuel: target AFR", "",		0.65,	1.2,		0.7,	0.75,		1.1,	1.15,	3,	2
 
 gaugeCategory = Throttle Body (incl. ETB)
 	pedalPositionGauge = throttlePedalPosition, @@GAUGE_NAME_THROTTLE_PEDAL@@,		"%",	0,	120,		0,	0,	100,	100,	1,	1


### PR DESCRIPTION
these should match the `"Fuel: math" gauge category and Datalog entries, no?