### PR TITLE
Control injectors with a mask rather than pointers

### DIFF
--- a/firmware/controllers/engine_cycle/fuel_schedule.h
+++ b/firmware/controllers/engine_cycle/fuel_schedule.h
@@ -47,14 +47,14 @@ public:
 	// TODO: this should be private
 	uint16_t outputsMask = 0;
 	float injectionStartAngle = 0;
-	efidur_t splitInjectionDuration;
 };
 
 union InjectorContext {
 	struct {
-		uint16_t outputsMask = 0;
-		uint8_t eventIndex = 0xFF;
-		uint8_t stage2Active = false;
+		uint16_t outputsMask:12 = 0;
+		uint8_t eventIndex:4 = 0xF;
+		uint16_t splitDurationUs:15 = 0;
+		bool stage2Active:1 = false;
 	};
 	void* _pad;
 };

--- a/firmware/controllers/engine_cycle/fuel_schedule.h
+++ b/firmware/controllers/engine_cycle/fuel_schedule.h
@@ -45,13 +45,25 @@ private:
 
 public:
 	// TODO: this should be private
-	InjectorOutputPin *outputs[MAX_WIRES_COUNT];
-	InjectorOutputPin *outputsStage2[MAX_WIRES_COUNT];
+	uint16_t outputsMask = 0;
 	float injectionStartAngle = 0;
 	efidur_t splitInjectionDuration;
 };
 
-void turnInjectionPinHigh(uintptr_t arg);
+union InjectorContext {
+	struct {
+		uint16_t outputsMask = 0;
+		uint8_t eventIndex = 0xFF;
+		uint8_t stage2Active = false;
+	};
+	void* _pad;
+};
+
+static_assert(sizeof(InjectorContext) <= sizeof(void*));
+
+void startInjection(InjectorContext ctx);
+void endInjection(InjectorContext ctx);
+void endInjectionStage2(InjectorContext ctx);
 
 
 /**
@@ -69,8 +81,6 @@ public:
 
 	// Calculate injector opening angle, pins, and mode for all injectors
 	void addFuelEvents();
-
-	void resetOverlapping();
 
 	/**
 	 * injection events, per cylinder

--- a/firmware/controllers/engine_cycle/main_trigger_callback.h
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.h
@@ -12,6 +12,3 @@
 #include "event_registry.h"
 
 void mainTriggerCallback(uint32_t trgEventIndex, efitick_t edgeTimestamp, angle_t currentPhase, angle_t nextPhase);
-
-void endSimultaneousInjection(InjectionEvent *event);
-void turnInjectionPinLow(uintptr_t arg);

--- a/firmware/controllers/engine_cycle/prime_injection.cpp
+++ b/firmware/controllers/engine_cycle/prime_injection.cpp
@@ -104,12 +104,18 @@ void PrimeController::onPrimeStart() {
 
 	// Open all injectors, schedule closing later
 	m_isPriming = true;
-	startSimultaneousInjection();
+
+	InjectorContext ctx;
+	ctx.outputsMask = (1 << engineConfiguration->cylindersCount) - 1;
+
+	startInjection(ctx);
 	getScheduler()->schedule("prime end", nullptr, endTime, { onPrimeEndAdapter, this });
 }
 
 void PrimeController::onPrimeEnd() {
-	endSimultaneousInjectionOnlyTogglePins();
+	InjectorContext ctx;
+	ctx.outputsMask = (1 << engineConfiguration->cylindersCount) - 1;
+	endInjection(ctx);
 
 	m_isPriming = false;
 }

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -160,7 +160,7 @@ void RpmCalculator::assignRpmValue(float floatRpmValue) {
 
 void RpmCalculator::setRpmValue(float value) {
 	assignRpmValue(value);
-	spinning_state_e oldState = state;
+
 	// Change state
 	if (cachedRpmValue == 0) {
 		state = STOPPED;
@@ -178,20 +178,6 @@ void RpmCalculator::setRpmValue(float value) {
 		 */
 		state = CRANKING;
 	}
-#if EFI_ENGINE_CONTROL
-	// This presumably fixes injection mode change for cranking-to-running transition.
-	// 'isSimultaneous' flag should be updated for events if injection modes differ for cranking and running.
-	if (state != oldState && engineConfiguration->crankingInjectionMode != engineConfiguration->injectionMode) {
-		// Reset the state of all injectors: when we change fueling modes, we could
-		// immediately reschedule an injection that's currently underway.  That will cause
-		// the injector's overlappingCounter to get out of sync with reality.  As the fix,
-		// every injector's state is forcibly reset just before we could cause that to happen.
-		engine->injectionEvents.resetOverlapping();
-
-		// reschedule all injection events now that we've reset them
-		engine->injectionEvents.addFuelEvents();
-	}
-#endif
 }
 
 spinning_state_e RpmCalculator::getState() const {

--- a/firmware/controllers/system/injection_gpio.cpp
+++ b/firmware/controllers/system/injection_gpio.cpp
@@ -6,20 +6,6 @@
 
 extern bool printFuelDebug;
 
-void startSimultaneousInjection(void*) {
-	efitick_t nowNt = getTimeNowNt();
-	for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
-		enginePins.injectors[i].open(nowNt);
-	}
-}
-
-void endSimultaneousInjectionOnlyTogglePins() {
-	efitick_t nowNt = getTimeNowNt();
-	for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
-		enginePins.injectors[i].close(nowNt);
-	}
-}
-
 InjectorOutputPin::InjectorOutputPin() : NamedOutputPin() {
 	m_overlappingCounter = 1; // Force update in reset
 	reset();

--- a/firmware/controllers/system/injection_gpio.h
+++ b/firmware/controllers/system/injection_gpio.h
@@ -6,9 +6,6 @@
 
 #include "efi_output.h"
 
-void startSimultaneousInjection(void* = nullptr);
-void endSimultaneousInjectionOnlyTogglePins();
-
 class InjectorOutputPin final : public NamedOutputPin {
 public:
 	InjectorOutputPin();

--- a/firmware/controllers/system/timer/scheduler.h
+++ b/firmware/controllers/system/timer/scheduler.h
@@ -17,10 +17,6 @@ std::enable_if_t<
 // constexpr support needs compiler magic
 bit_cast(const From& src) noexcept
 {
-	static_assert(std::is_trivially_constructible_v<To>,
-		"This implementation additionally requires "
-		"destination type to be trivially constructible");
-
 	To dst;
 	std::memcpy(&dst, &src, sizeof(To));
 	return dst;
@@ -42,7 +38,7 @@ public:
 	template <typename TArg>
 	action_s(void (*callback)(TArg), TArg param) : m_callback(bit_cast<schfunc_t>(callback)), m_param(bit_cast<void*>(param)) {
 		// The object must be exactly the size of a pointer
-		static_assert(sizeof(TArg) == sizeof(void*));
+		static_assert(sizeof(TArg) <= sizeof(void*));
 	}
 
 	void execute();

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -323,7 +323,6 @@ void EngineTestHelper::assertEvent(const char *msg, int index, void *callback, e
 	ASSERT_EQ(ctx.eventIndex, injectorIndex);
 }
 
-
 void EngineTestHelper::applyTriggerWaveform() {
 	engine.updateTriggerWaveform();
 

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -279,14 +279,12 @@ void EngineTestHelper::fireTriggerEvents(int count) {
 	fireTriggerEvents2(count, 5); // 5ms
 }
 
-void EngineTestHelper::assertInjectorUpEvent(const char *msg, int eventIndex, efitimeus_t momentX, long injectorIndex) {
-	InjectionEvent *event = &engine.injectionEvents.elements[injectorIndex];
-	assertEvent(msg, eventIndex, (void*)turnInjectionPinHigh, momentX, event);
+void EngineTestHelper::assertInjectorUpEvent(const char *msg, int eventIndex, efitimeus_t momentX, int injectorIndex) {
+	assertEvent(msg, eventIndex, (void*)startInjection, momentX, injectorIndex);
 }
 
-void EngineTestHelper::assertInjectorDownEvent(const char *msg, int eventIndex, efitimeus_t momentX, long injectorIndex) {
-	InjectionEvent *event = &engine.injectionEvents.elements[injectorIndex];
-	assertEvent(msg, eventIndex, (void*)turnInjectionPinLow, momentX, event);
+void EngineTestHelper::assertInjectorDownEvent(const char *msg, int eventIndex, efitimeus_t momentX, int injectorIndex) {
+	assertEvent(msg, eventIndex, (void*)endInjection, momentX, injectorIndex);
 }
 
 scheduling_s * EngineTestHelper::assertEvent5(const char *msg, int index, void *callback, efitimeus_t expectedTimestamp) {
@@ -318,12 +316,11 @@ scheduling_s * EngineTestHelper::assertScheduling(const char *msg, int index, sc
 	return actual;
 }
 
-void EngineTestHelper::assertEvent(const char *msg, int index, void *callback, efitimeus_t momentX, InjectionEvent *expectedEvent) {
+void EngineTestHelper::assertEvent(const char *msg, int index, void *callback, efitimeus_t momentX, int injectorIndex) {
 	scheduling_s *event = assertEvent5(msg, index, callback, momentX);
 
-	InjectionEvent *actualEvent = (InjectionEvent *)event->action.getArgument();
-
-	ASSERT_EQ(expectedEvent->outputs[0], actualEvent->outputs[0]) << msg;
+	InjectorContext ctx = bit_cast<InjectorContext>(event->action.getArgument());
+	ASSERT_EQ(ctx.eventIndex, injectorIndex);
 }
 
 

--- a/unit_tests/engine_test_helper.h
+++ b/unit_tests/engine_test_helper.h
@@ -89,9 +89,9 @@ public:
 
 	const AngleBasedEvent* assertTriggerEvent(const char *msg, int index, AngleBasedEvent *expected, void *callback, angle_t enginePhase);
 
-	void assertEvent(const char *msg, int index, void *callback, efitimeus_t momentX, InjectionEvent *event);
-	void assertInjectorUpEvent(const char *msg, int eventIndex, efitimeus_t momentX, long injectorIndex);
-	void assertInjectorDownEvent(const char *msg, int eventIndex, efitimeus_t momentX, long injectorIndex);
+	void assertEvent(const char *msg, int index, void *callback, efitimeus_t momentX, int injectorIndex);
+	void assertInjectorUpEvent(const char *msg, int eventIndex, efitimeus_t momentX, int injectorIndex);
+	void assertInjectorDownEvent(const char *msg, int eventIndex, efitimeus_t momentX, int injectorIndex);
 	// todo: open question if this is worth a helper method or should be inlined?
 	void assertRpm(int expectedRpm, const char *msg = "RPM");
 

--- a/unit_tests/tests/ignition_injection/injection_mode_transition.cpp
+++ b/unit_tests/tests/ignition_injection/injection_mode_transition.cpp
@@ -62,19 +62,24 @@ TEST(fuelControl, transitionIssue1592) {
 
 	{
 		// Injector 2 should be scheduled to open then close
-		void* inj2 = reinterpret_cast<void*>(&engine->injectionEvents.elements[1]);
+		InjectorContext ctx;
+		ctx.eventIndex = 1;
+		// fire cyl 2+3 (batch)
+		ctx.outputsMask = 1 << 1 | 1 << 2;
+
+		void* ctxAsPtr = bit_cast<void*>(ctx);
 
 		ASSERT_EQ(engine->scheduler.size(), 2);
 
 		// Check that the action is correct - we don't care about the timing necessarily
 		auto sched_open = engine->scheduler.getForUnitTest(0);
-		ASSERT_EQ(sched_open->action.getArgument(), inj2);
-		ASSERT_EQ(sched_open->action.getCallback(), (void(*)(void*))turnInjectionPinHigh);
+		ASSERT_EQ(sched_open->action.getArgument(), ctxAsPtr);
+		ASSERT_EQ(sched_open->action.getCallback(), (void(*)(void*))startInjection);
 
 		auto sched_close = engine->scheduler.getForUnitTest(1);
 		// Next action should be closing the same injector
-		ASSERT_EQ(sched_close->action.getArgument(), inj2);
-		ASSERT_EQ(sched_close->action.getCallback(), (void(*)(void*))turnInjectionPinLow);
+		ASSERT_EQ(sched_close->action.getArgument(), ctxAsPtr);
+		ASSERT_EQ(sched_close->action.getCallback(), (void(*)(void*))endInjection);
 	}
 
 	// Run the engine for some revs

--- a/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
+++ b/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
@@ -27,9 +27,9 @@ TEST(engine, testPlainCrankingWithoutAdvancedFeatures) {
 	// two simultaneous injections
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "plain#2";
 
-	eth.assertEvent5("sim start", 0, (void*)startSimultaneousInjection, 100000 - 1625);
+	eth.assertEvent5("sim start", 0, (void*)startInjection, 100000 - 1625);
 	// -1 because ugh floating point math
-	eth.assertEvent5("sim end", 1, (void*)endSimultaneousInjection, 100000 - 1);
+	eth.assertEvent5("sim end", 1, (void*)endInjection, 100000 - 1);
 }
 
 

--- a/unit_tests/tests/trigger/test_fasterEngineSpinningUp.cpp
+++ b/unit_tests/tests/trigger/test_fasterEngineSpinningUp.cpp
@@ -53,8 +53,8 @@ TEST(cranking, testFasterEngineSpinningUp) {
 	// test if ignition mode is temporary changed to wasted spark, if set to individual coils
 	ASSERT_EQ(IM_WASTED_SPARK, getCurrentIgnitionMode());
 	// check real events
-	eth.assertEvent5("inj start#1", 0, (void*)startSimultaneousInjection, 97500);
-	eth.assertEvent5("inj end#1", 1, (void*)endSimultaneousInjection, 100000);
+	eth.assertEvent5("inj start#1", 0, (void*)startInjection, 97500);
+	eth.assertEvent5("inj end#1", 1, (void*)endInjection, 100000);
 
 	// skip the rest of the cycle
 	eth.moveTimeForwardUs(MS2US(200));
@@ -75,8 +75,8 @@ TEST(cranking, testFasterEngineSpinningUp) {
 	// two simultaneous injections
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "plain#2";
 	// check real events
-	eth.assertEvent5("inj start#2", 0, (void*)startSimultaneousInjection, 148375);
-	eth.assertEvent5("inj end#2", 1, (void*)endSimultaneousInjection, 149999);
+	eth.assertEvent5("inj start#2", 0, (void*)startInjection, 148375);
+	eth.assertEvent5("inj end#2", 1, (void*)endInjection, 149999);
 
 	// Now perform a fake VVT sync and check that ignition mode changes to sequential
 	engine->triggerCentral.syncAndReport(2, 0);
@@ -99,8 +99,8 @@ TEST(cranking, testFasterEngineSpinningUp) {
 
 	// check real events for sequential injection
 	// Note: See addFuelEvents() fix inside setRpmValue()!
-	eth.assertEvent5("inj start#3", 0, (void*)turnInjectionPinHigh, -31625);
-	eth.assertEvent5("inj end#3", 1, (void*)turnInjectionPinLow, -30001);
+	eth.assertEvent5("inj start#3", 0, (void*)startInjection, -30326);
+	eth.assertEvent5("inj end#3", 1, (void*)endInjection, -28702);
 }
 
 static void doTestFasterEngineSpinningUp60_2(int startUpDelayMs, int rpm1, int expectedRpm) {

--- a/unit_tests/tests/trigger/test_injection_scheduling.cpp
+++ b/unit_tests/tests/trigger/test_injection_scheduling.cpp
@@ -11,10 +11,6 @@ using ::testing::Not;
 using ::testing::Property;
 using ::testing::Truly;
 
-static bool ActionArgumentHasLowBitSet(const action_s& a) {
-	return (reinterpret_cast<uintptr_t>(a.getArgument()) & 1) != 0;
-}
-
 TEST(injectionScheduling, InjectionIsScheduled) {
 	StrictMock<MockExecutor> mockExec;
 
@@ -24,9 +20,6 @@ TEST(injectionScheduling, InjectionIsScheduled) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	InjectorOutputPin pin;
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
 
 	// Injection duration of 20ms
 	MockInjectorModel2 im;
@@ -35,6 +28,13 @@ TEST(injectionScheduling, InjectionIsScheduled) {
 
 	engine->rpmCalculator.oneDegreeUs = 100;
 
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = false;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
+
 	{
 		InSequence is;
 
@@ -42,10 +42,10 @@ TEST(injectionScheduling, InjectionIsScheduled) {
 		// rising edge 5 degrees from now
 		float nt5deg = USF2NT(engine->rpmCalculator.oneDegreeUs * 5);
 		efitick_t startTime = nowNt + nt5deg;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Not(Truly(ActionArgumentHasLowBitSet))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 		// falling edge 20ms later
 		efitick_t endTime = startTime + MS2NT(20);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 	}
 
 	// Event scheduled at 125 degrees
@@ -67,9 +67,13 @@ TEST(injectionScheduling, InjectionIsScheduledDualStage) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	InjectorOutputPin pin;
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
+
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = true;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
 
 	engine->rpmCalculator.oneDegreeUs = 100;
 
@@ -92,13 +96,13 @@ TEST(injectionScheduling, InjectionIsScheduledDualStage) {
 		// rising edge 5 degrees from now
 		float nt5deg = USF2NT(engine->rpmCalculator.oneDegreeUs * 5);
 		efitick_t startTime = nowNt + nt5deg;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Truly(ActionArgumentHasLowBitSet)));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 		// falling edge (primary) 20ms later
 		efitick_t endTime1 = startTime + MS2NT(20);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime1, Truly(ActionArgumentHasLowBitSet)));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime1, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 		// falling edge (secondary) 10ms later
 		efitick_t endTime2 = startTime + MS2NT(10);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime2, Property(&action_s::getArgument, Eq(&event))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime2, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 	}
 
 	// Event scheduled at 125 degrees
@@ -117,9 +121,13 @@ TEST(injectionScheduling, InjectionIsScheduledBeforeWraparound) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	InjectorOutputPin pin;
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
+
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = false;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
 
 	// Injection duration of 20ms
 	MockInjectorModel2 im;
@@ -135,10 +143,10 @@ TEST(injectionScheduling, InjectionIsScheduledBeforeWraparound) {
 		// rising edge 5 degrees from now
 		float nt5deg = USF2NT(engine->rpmCalculator.oneDegreeUs * 5);
 		efitick_t startTime = nowNt + nt5deg;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Not(Truly(ActionArgumentHasLowBitSet))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 		// falling edge 20ms later
 		efitick_t endTime = startTime + MS2NT(20);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 	}
 
 	// Event scheduled at 715 degrees
@@ -157,9 +165,13 @@ TEST(injectionScheduling, InjectionIsScheduledAfterWraparound) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	InjectorOutputPin pin;
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
+
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = false;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
 
 	// Injection duration of 20ms
 	MockInjectorModel2 im;
@@ -175,10 +187,10 @@ TEST(injectionScheduling, InjectionIsScheduledAfterWraparound) {
 		// rising edge 15 degrees from now
 		float nt5deg = USF2NT(engine->rpmCalculator.oneDegreeUs * 15);
 		efitick_t startTime = nowNt + nt5deg;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Not(Truly(ActionArgumentHasLowBitSet))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 		// falling edge 20ms later
 		efitick_t endTime = startTime + MS2NT(20);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
 	}
 
 	// Event scheduled at 5 degrees
@@ -198,9 +210,13 @@ TEST(injectionScheduling, InjectionNotScheduled) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	InjectorOutputPin pin;
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
+
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = false;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
 
 	// Expect no calls to injector model
 	StrictMock<MockInjectorModel2> im;
@@ -222,38 +238,33 @@ TEST(injectionScheduling, InjectionNotScheduled) {
 	event.onTriggerTooth(nowNt, 130, 140);
 }
 
-TEST(injectionScheduling, SplitInjectionScheduled) {
-	StrictMock<MockExecutor> mockExec;
+// TEST(injectionScheduling, SplitInjectionScheduled) {
+// 	StrictMock<MockExecutor> mockExec;
 
-	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
-	engine->scheduler.setMockExecutor(&mockExec);
+// 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+// 	engine->scheduler.setMockExecutor(&mockExec);
 
-	InjectionEvent event;
-	uintptr_t arg = reinterpret_cast<uintptr_t>(&event);
-	InjectorOutputPin pin;
-	pin.shortName = "test";
-	pin.injectorIndex = 0;
-	event.outputs[0] = &pin;
+// 	InjectionEvent event;
 
-	{
-		InSequence is;
+// 	{
+// 		InSequence is;
 
-		// Should schedule second half of split injection:
-		// - starts 2ms from now
-		// - duration 10ms (ends 12ms from now)
-		efitick_t nowNt = getTimeNowNt();
-		efitick_t startTime = nowNt + MS2NT(2);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(&event))));
-		efitick_t endTime = startTime + MS2NT(10);
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
-	}
+// 		// Should schedule second half of split injection:
+// 		// - starts 2ms from now
+// 		// - duration 10ms (ends 12ms from now)
+// 		efitick_t nowNt = getTimeNowNt();
+// 		efitick_t startTime = nowNt + MS2NT(2);
+// 		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(&event))));
+// 		efitick_t endTime = startTime + MS2NT(10);
+// 		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
+// 	}
 
-	// Split injection duration of 10ms
-	event.splitInjectionDuration = MS2NT(10);
+// 	// Split injection duration of 10ms
+// 	event.splitInjectionDuration = MS2NT(10);
 
-	// Close injector, should cause second half of split injection to be scheduled!
-	turnInjectionPinLow(arg);
+// 	// Close injector, should cause second half of split injection to be scheduled!
+// 	turnInjectionPinLow(arg);
 
-	// Expect it to get zeroed so we don't repeat ad infinitum
-	EXPECT_EQ(event.splitInjectionDuration, 0);
-}
+// 	// Expect it to get zeroed so we don't repeat ad infinitum
+// 	EXPECT_EQ(event.splitInjectionDuration, 0);
+// }

--- a/unit_tests/tests/trigger/test_injection_scheduling.cpp
+++ b/unit_tests/tests/trigger/test_injection_scheduling.cpp
@@ -238,33 +238,33 @@ TEST(injectionScheduling, InjectionNotScheduled) {
 	event.onTriggerTooth(nowNt, 130, 140);
 }
 
-// TEST(injectionScheduling, SplitInjectionScheduled) {
-// 	StrictMock<MockExecutor> mockExec;
+TEST(injectionScheduling, SplitInjectionScheduled) {
+	StrictMock<MockExecutor> mockExec;
 
-// 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
-// 	engine->scheduler.setMockExecutor(&mockExec);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engine->scheduler.setMockExecutor(&mockExec);
 
-// 	InjectionEvent event;
+	InjectionEvent event;
 
-// 	{
-// 		InSequence is;
+	{
+		InSequence is;
 
-// 		// Should schedule second half of split injection:
-// 		// - starts 2ms from now
-// 		// - duration 10ms (ends 12ms from now)
-// 		efitick_t nowNt = getTimeNowNt();
-// 		efitick_t startTime = nowNt + MS2NT(2);
-// 		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(&event))));
-// 		efitick_t endTime = startTime + MS2NT(10);
-// 		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(&event))));
-// 	}
+		// Should schedule second half of split injection:
+		// - starts 2ms from now
+		// - duration 10ms (ends 12ms from now)
+		efitick_t nowNt = getTimeNowNt();
+		efitick_t startTime = nowNt + MS2NT(2);
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
+		efitick_t endTime = startTime + MS2NT(10);
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, Property(&action_s::getArgument, Eq(ctxAsPtr))));
+	}
 
-// 	// Split injection duration of 10ms
-// 	event.splitInjectionDuration = MS2NT(10);
+	// Split injection duration of 10ms
+	event.splitInjectionDuration = MS2NT(10);
 
-// 	// Close injector, should cause second half of split injection to be scheduled!
-// 	turnInjectionPinLow(arg);
+	// Close injector, should cause second half of split injection to be scheduled!
+	turnInjectionPinLow(arg);
 
-// 	// Expect it to get zeroed so we don't repeat ad infinitum
-// 	EXPECT_EQ(event.splitInjectionDuration, 0);
-// }
+	// Expect it to get zeroed so we don't repeat ad infinitum
+	EXPECT_EQ(event.splitInjectionDuration, 0);
+}

--- a/unit_tests/tests/trigger/test_injection_scheduling.cpp
+++ b/unit_tests/tests/trigger/test_injection_scheduling.cpp
@@ -246,6 +246,16 @@ TEST(injectionScheduling, SplitInjectionScheduled) {
 
 	InjectionEvent event;
 
+	InjectorContext ctx;
+	ctx.outputsMask = 0;
+	ctx.eventIndex = 0;
+	ctx.stage2Active = false;
+
+	void* ctxAsPtr = bit_cast<void*>(ctx);
+
+	// Split injection events should be called with no remaining split duration
+	ctx.splitDurationUs = 0;
+
 	{
 		InSequence is;
 
@@ -260,11 +270,8 @@ TEST(injectionScheduling, SplitInjectionScheduled) {
 	}
 
 	// Split injection duration of 10ms
-	event.splitInjectionDuration = MS2NT(10);
+	ctx.splitDurationUs = 10000;
 
 	// Close injector, should cause second half of split injection to be scheduled!
-	turnInjectionPinLow(arg);
-
-	// Expect it to get zeroed so we don't repeat ad infinitum
-	EXPECT_EQ(event.splitInjectionDuration, 0);
+	endInjection(ctx);
 }

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -381,24 +381,19 @@ TEST(trigger, testTriggerDecoder) {
 	testTriggerDecoder2("vw ABA", engine_type_e::VW_ABA, 0, 0.51666, 0.0);
 }
 
-static void assertInjectionEventBase(const char *msg, InjectionEvent *ev, int injectorIndex, int eventIndex, angle_t angleOffset) {
-	EXPECT_EQ(injectorIndex, ev->outputs[0]->injectorIndex) << msg << "inj index";
+static void assertInjectionEventBase(const char *msg, InjectionEvent *ev, uint16_t injectorOutputMask, angle_t angleOffset) {
+	EXPECT_EQ(ev->outputsMask, injectorOutputMask) << msg << "inj output mask";
 	EXPECT_NEAR_M4(angleOffset, ev->injectionStartAngle) << msg << "inj index";
 }
 
 static void assertInjectionEvent(const char *msg, InjectionEvent *ev, int injectorIndex, int eventIndex, angle_t angleOffset) {
-	assertInjectionEventBase(msg, ev, injectorIndex, eventIndex, angleOffset);
-
-	// There should NOT be a second injector configured
-	EXPECT_EQ(nullptr, ev->outputs[1]);
+	assertInjectionEventBase(msg, ev, (1 << injectorIndex), angleOffset);
 }
 
 static void assertInjectionEventBatch(const char *msg, InjectionEvent *ev, int injectorIndex, int secondInjectorIndex, int eventIndex, angle_t angleOffset) {
-	assertInjectionEventBase(msg, ev, injectorIndex, eventIndex, angleOffset);
-
-	// There should be a second injector - confirm it's the correct one
-	ASSERT_NE(nullptr, ev->outputs[1]);
-	EXPECT_EQ(secondInjectorIndex, ev->outputs[1]->injectorIndex);
+	uint16_t mask = (1 << injectorIndex) | (1 << secondInjectorIndex);
+	
+	assertInjectionEventBase(msg, ev, mask, angleOffset);
 }
 
 static void setTestBug299(EngineTestHelper *eth) {


### PR DESCRIPTION
Scheduled injector events should have everything they need in the arg, rather than a pointer to an object whose state can change asynchronously.

Previously you could get:
- Open+close events scheduled
- Open event fires
- `InjectionEvent::update` is called, which changes which outputs are in use
- Close event fires, but with different outputs (!!!)
The effect of this is that you could jam injectors permanently open if they were opened, then removed from an event before closing.

This change stores all of the information about what to do in the argument itself:
- 16 bit mask of which injectors to operate on (00000001 is injector 1, 10001000 is injectors 4 and 8)
- The index of the event to update when injection is complete
- A bit for whether the second stage should fire
- Duration of any split injection to fire after the first injection (for injector testing)

Once the argument is calculated, both open+close events are scheduled at once using the same argument, guaranteeing pairing of open+close events.

Some neat side effects:
- Different injection modes (and even priming!) can all use the same open/close functions, just with different sets of bits masked. Simultaneous (and priming) masks all (0x003F for a 6 cylinder, for example), sequential masks one, batch masks two, etc.
- We no longer need to reset overlapped injection whenever the RPM state changes, as we're now impervious to hung injectors due to injection mode changes