### PR TITLE
turn on guard page for F4

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
@@ -36,7 +36,7 @@ flash_size = DEFINED(IS_BOOTLOADER) ? bootloader_size : 768k;
 image_size = DEFINED(HAS_BOOTLOADER) ? (flash_size - bootloader_size) : flash_size;
 
 /* OpenBLT <-> main FW shared area */
-_OpenBLT_Shared_Params_Size = DEFINED(HAS_BOOTLOADER) || DEFINED(IS_BOOTLOADER) ? 16 : 0;
+_OpenBLT_Shared_Params_Size = DEFINED(HAS_BOOTLOADER) || DEFINED(IS_BOOTLOADER) ? 32 : 0;
 
 MEMORY
 {

--- a/firmware/hw_layer/ports/stm32/stm32f4/cfg/chconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/cfg/chconf.h
@@ -745,6 +745,9 @@
  */
 #define CORTEX_ENABLE_WFI_IDLE TRUE
 
+#define PORT_ENABLE_GUARD_PAGES TRUE
+#define PORT_USE_GUARD_MPU_REGION       MPU_REGION_6
+
 #endif  /* CHCONF_H */
 
 /** @} */


### PR DESCRIPTION
Enable MPU-based stack guard for F4 as well. Despite being a cortex-m4, it's still arm-v7m, which has a fully functional MPU.