### PR TITLE
enable F7/H7 double precision floating point

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -132,11 +132,6 @@ ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
   USE_EXCEPTIONS_STACKSIZE = 0x1000
 endif
 
-# Enables the use of FPU on Cortex-M4 (no, softfp, hard).
-ifeq ($(USE_FPU),)
-  USE_FPU = hard
-endif
-
 # and this is not working for be :( See https://github.com/rusefi/rusefi/issues/638
 # use -j4 unless some value was specified
 NUMJOBS=${NUMJOBS:-" -j4 "}

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -102,11 +102,6 @@ ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
   USE_EXCEPTIONS_STACKSIZE = 0x1000
 endif
 
-# Enables the use of FPU on Cortex-M4 (no, softfp, hard).
-ifeq ($(USE_FPU),)
-  USE_FPU = hard
-endif
-
 #
 # Architecture or project specific options
 ##############################################################################

--- a/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
@@ -8,6 +8,7 @@ HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/mpu_util.cpp \
 					$(HW_STM32_PORT_DIR)/flash_int_f4_f7.cpp \
 
 MCU = cortex-m4
+USE_FPU = hard
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/STM32F4.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_STM32F4_DISCOVERY/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/cfg

--- a/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
@@ -12,6 +12,8 @@ USE_OPT += -falign-functions=16
 
 DDEFS += -DSTM32F767xx
 MCU = cortex-m7
+USE_FPU = hard
+USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-d16
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/STM32F7.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_F767ZI/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/cfg

--- a/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
@@ -12,6 +12,8 @@ USE_OPT += -falign-functions=16
 
 DDEFS += -DSTM32H743xx
 MCU = cortex-m7
+USE_FPU = hard
+USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-d16
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/STM32H743xI.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_H743ZI/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/cfg


### PR DESCRIPTION
These CPUs have a double precision FPU, and things like printf use double, so enable it to get the free code size back (~2.5k).