### PR TITLE
idle entry target ramp

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -32,6 +32,7 @@ or
 
 ### Added
  - Allow fractional tachometer pulse ratio for fine tachometer calibration
+ - Add an option to ramp the idle target down as engine speed returns to idle. Makes the running -> idle transition much smoother while in closed loop mode #570
 
 ## February 2025 Release
 

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -40,13 +40,15 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
 	// Higher exit than entry to add some hysteresis to avoid bouncing around upper threshold
 	float exitRpm = target + 1.5 * rpmUpperLimit;
 
-	// Ramp the target down from the transition RPM to normal over a few seconds
-	float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
-	target += interpolateClamped(
-		0, rpmUpperLimit,
-		3, 0,
-		timeSinceIdleEntry
-	);
+	if (engineConfiguration->idleReturnTargetRamp) {
+		// Ramp the target down from the transition RPM to normal over a few seconds
+		float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
+		target += interpolateClamped(
+			0, rpmUpperLimit,
+			3, 0,
+			timeSinceIdleEntry
+		);
+	}
 
 	idleTarget = target;
 	return { target, entryRpm, exitRpm };

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -32,8 +32,11 @@ struct IIdleController {
 		// If below this speed, enter idle
 		float IdleEntryRpm;
 
+		// If above this speed, exit idle
+		float IdleExitRpm;
+
 		bool operator==(const TargetInfo& other) const {
-			return ClosedLoopTarget == other.ClosedLoopTarget && IdleEntryRpm == other.IdleEntryRpm;
+			return ClosedLoopTarget == other.ClosedLoopTarget && IdleEntryRpm == other.IdleEntryRpm && IdleExitRpm == other.IdleExitRpm;
 		}
 	};
 

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -91,6 +91,8 @@ private:
 	int m_lastTargetRpm = 0;
 	efitimeus_t restoreAfterPidResetTimeUs = 0;
 
+	Timer m_timeInIdlePhase;
+
 	// This is stored by getClosedLoop and used in case we want to "do nothing"
 	float m_lastAutomaticPosition = 0;
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -674,7 +674,7 @@ bit is_enabled_spi_2
 	bit enabledStep1Limiter
 	bit verboseTLE8888
 	bit enableVerboseCanTx;CAN broadcast using custom FOME protocol\nenable can_broadcast/disable can_broadcast
-	bit idleReturnTargetRamp
+	bit idleReturnTargetRamp;Ramp the idle target down from the entry threshold over 3 seconds when returning to idle. Helps prevent overshooting (below) the idle target while returning to idle from coasting.
 	bit unused644b11
 	bit measureMapOnlyInOneCylinder;Useful for individual intakes
 	bit stepperForceParkingEveryRestart

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -674,7 +674,7 @@ bit is_enabled_spi_2
 	bit enabledStep1Limiter
 	bit verboseTLE8888
 	bit enableVerboseCanTx;CAN broadcast using custom FOME protocol\nenable can_broadcast/disable can_broadcast
-	bit unused644b10
+	bit idleReturnTargetRamp
 	bit unused644b11
 	bit measureMapOnlyInOneCylinder;Useful for individual intakes
 	bit stepperForceParkingEveryRestart

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3420,6 +3420,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Use idle ignition table",	useSeparateAdvanceForIdle
 		field = "Use idle VE table",		useSeparateVeForIdle
 		field = "Override Idle VE table load axis", idleVeOverrideMode, { useSeparateVeForIdle }
+		field = "Ramp target on return to idle",	idleReturnTargetRamp, { idleMode == @@idle_mode_e_IM_AUTO@@ }
 		field = "Use idle tables for cranking taper",		useSeparateIdleTablesForCrankingTaper
 		field = "Use coasting idle table",	useIacTableForCoasting
 
@@ -4591,7 +4592,6 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Artificial Misfire",						artificialTestMisfire
 		field = "Instant Rpm Range",                    instantRpmRange
 		field = "Always use instant RPM",				alwaysInstantRpm
-		field = "Idle return target ramp",				idleReturnTargetRamp
 		field = "Modeled flow idle",					modeledFlowIdle
 		field = "Max idle flow",						idleMaximumAirmass
 		field = verboseIsoTp,									verboseIsoTp

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4590,6 +4590,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Artificial Misfire",						artificialTestMisfire
 		field = "Instant Rpm Range",                    instantRpmRange
 		field = "Always use instant RPM",				alwaysInstantRpm
+		field = "Idle return target ramp",				idleReturnTargetRamp
 		field = "Modeled flow idle",					modeledFlowIdle
 		field = "Max idle flow",						idleMaximumAirmass
 		field = verboseIsoTp,									verboseIsoTp

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -59,12 +59,12 @@ TEST(idle_v2, testTargetRpm) {
 	}
 
 	engineConfiguration->idlePidRpmUpperLimit = 50;
-	EXPECT_EQ((TgtInfo{100, 150}), dut.getTargetRpm(10));
-	EXPECT_EQ((TgtInfo{500, 550}), dut.getTargetRpm(50));
+	EXPECT_EQ((TgtInfo{100, 150, 175}), dut.getTargetRpm(10));
+	EXPECT_EQ((TgtInfo{500, 550, 575}), dut.getTargetRpm(50));
 
 	engineConfiguration->idlePidRpmUpperLimit = 73;
-	EXPECT_EQ((TgtInfo{100, 173}), dut.getTargetRpm(10));
-	EXPECT_EQ((TgtInfo{500, 573}), dut.getTargetRpm(50));
+	EXPECT_EQ((TgtInfo{100, 173, 209.5}), dut.getTargetRpm(10));
+	EXPECT_EQ((TgtInfo{500, 573, 609.5}), dut.getTargetRpm(50));
 }
 
 TEST(idle_v2, testDeterminePhase) {
@@ -82,6 +82,7 @@ TEST(idle_v2, testDeterminePhase) {
 
 	// Idling threshold is 1000 + 100 rpm
 	targetInfo.IdleEntryRpm = 1000 + 100;
+	targetInfo.IdleExitRpm = 1000 + 100;
 
 	// First test stopped engine
 	engine->rpmCalculator.setRpmValue(0);
@@ -445,7 +446,7 @@ TEST(idle_v2, IntegrationManual) {
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
 
-	TgtInfo target{1000, 1100};
+	TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))
@@ -480,7 +481,7 @@ TEST(idle_v2, IntegrationAutomatic) {
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
 
-	TgtInfo target{1000, 1100};
+	TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))
@@ -518,7 +519,7 @@ TEST(idle_v2, IntegrationClamping) {
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
 
-	TgtInfo target{1000, 1100};
+	TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -116,6 +116,25 @@ TEST(idle_v2, testDeterminePhase) {
 	// Below TPS but above RPM should be outside the zone
 	EXPECT_EQ(ICP::Coasting, dut.determinePhase(1101, targetInfo, 0, 0, 10));
 	EXPECT_EQ(ICP::Coasting, dut.determinePhase(5000, targetInfo, 0, 0, 10));
+
+	// Check hysteresis behavior: entry RPM 1100, exit 1200
+	targetInfo.IdleEntryRpm = 1000 + 100;
+	targetInfo.IdleExitRpm = 1000 + 200;
+
+	// Below entry: idling
+	EXPECT_EQ(ICP::Idling, dut.determinePhase(1050, targetInfo, 0, 0, 10));
+
+	// Between thresholds: still idling
+	EXPECT_EQ(ICP::Idling, dut.determinePhase(1150, targetInfo, 0, 0, 10));
+
+	// Above exit: coasting
+	EXPECT_EQ(ICP::Coasting, dut.determinePhase(1250, targetInfo, 0, 0, 10));
+
+	// Between thresholds: still coasting
+	EXPECT_EQ(ICP::Coasting, dut.determinePhase(1150, targetInfo, 0, 0, 10));
+
+	// Below entry: idling
+	EXPECT_EQ(ICP::Idling, dut.determinePhase(1050, targetInfo, 0, 0, 10));
 }
 
 TEST(idle_v2, crankingOpenLoop) {


### PR DESCRIPTION
Instead of slamming to the target and overshooting, ramp the target down as we approach idle for smoother return-to-idle.

Also adds hysteresis to the idle entry threshold because you can't target the threshold without it.