### PR TITLE
stm32f7: fix board.h unification breaks

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32f7/board.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/board.h
@@ -40,6 +40,14 @@
 #define BOARD_OTG_NOVBUSSENS TRUE
 
 /*
+ * Default to input mode, with internal pulldown resistor enabled.
+ */
+#define EFI_PIN_MODE_DEFAULT PIN_MODE_INPUT
+#ifndef EFI_DR_DEFAULT
+#define EFI_DR_DEFAULT PIN_PUPDR_PULLDOWN
+#endif
+
+/*
  * Ethernet PHY type.
  */
 #define BOARD_PHY_ID                MII_LAN8742A_ID

--- a/firmware/hw_layer/ports/stm32/stm32f7/board.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/board.h
@@ -47,6 +47,9 @@
 #define EFI_DR_DEFAULT PIN_PUPDR_PULLDOWN
 #endif
 
+// See https://github.com/rusefi/rusefi/issues/397
+#define DEFAULT_GPIO_SPEED PIN_OSPEED_HIGH
+
 /*
  * Ethernet PHY type.
  */


### PR DESCRIPTION
some macros weren't ported here [yet]