### PR TITLE
ECUMaster CAN to EGT defaults

### DIFF
--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -216,9 +216,9 @@ static void processEgtCan(CanBusIndex busIndex, const CANRxFrame& frame) {
 
 	size_t offset = 0;
 
-	if (CAN_SID(frame) == 0x660) {
+	if (CAN_SID(frame) == 0x610) {
 		offset = 0;
-	} else if (CAN_SID(frame) == 0x661) {
+	} else if (CAN_SID(frame) == 0x611) {
 		offset = 4;
 	} else {
 		return;


### PR DESCRIPTION
One can update the ECUMaster device to use different can IDs, but, let's use the defaults from here so it can work out of the box. 

https://www.ecumaster.com/files/EGT2CAN/EgtToCanManual.pdf