### PR TITLE
selectable CAN wideband controller mode

### DIFF
--- a/firmware/config/boards/hellen/hellen_common.cpp
+++ b/firmware/config/boards/hellen/hellen_common.cpp
@@ -5,7 +5,7 @@
 static OutputPin megaEn;
 
 void hellenWbo() {
-	engineConfiguration->enableAemXSeries = true;
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
 }
 
 void setHellenCan() {

--- a/firmware/config/engines/mazda_miata_1_6.cpp
+++ b/firmware/config/engines/mazda_miata_1_6.cpp
@@ -324,7 +324,7 @@ void setMiataNa6_Polygonus() {
 	engineConfiguration->lowPressureFuel.value2 = 689.5;
 
 	// Built in wideband controller on bus 2
-	engineConfiguration->enableAemXSeries = true;
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
 	engineConfiguration->widebandOnSecondBus = true;
 	engineConfiguration->enableVerboseCanTx = true;
 

--- a/firmware/config/engines/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda_miata_vvt.cpp
@@ -737,7 +737,7 @@ void setMiataNbPolygonusCommon() {
 	engineConfiguration->idle.solenoidPin = PROTEUS_LS_10;
 
 	// Built in wideband controller on bus 2
-	engineConfiguration->enableAemXSeries = true;
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
 	engineConfiguration->widebandOnSecondBus = true;
 	engineConfiguration->enableVerboseCanTx = true;
 

--- a/firmware/config/engines/vw_b6.cpp
+++ b/firmware/config/engines/vw_b6.cpp
@@ -37,11 +37,6 @@ static inline void commonPassatB6() {
 		engineConfiguration->ignitionPins[i] = Gpio::Unassigned;
 	}
 
-//	engineConfiguration->canNbcType = CAN_BUS_NBC_VAG;
-
-	engineConfiguration->enableAemXSeries = true;
-
-
 	// Injectors flow 1214 cc/min at 100 bar pressure
 	engineConfiguration->injector.flow = 1214;
 	// Use high pressure sensor

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -643,8 +643,8 @@ enum class SelectedGear : uint8_t {
 	Low = 11,
 };
 
-enum class CanWidebandMode : uint8_t {
-	None = 0,
+enum class WidebandMode : uint8_t {
+	Analog = 0,
 	FOMEInternal = 1,
 	AemXSeries = 2,
 };

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -643,6 +643,12 @@ enum class SelectedGear : uint8_t {
 	Low = 11,
 };
 
+enum class CanWidebandMode : uint8_t {
+	None = 0,
+	FOMEInternal = 1,
+	AemXSeries = 2,
+};
+
 #define SC_Exhaust_First 1
 
 #endif // __cplusplus

--- a/firmware/controllers/can/can_tx.cpp
+++ b/firmware/controllers/can/can_tx.cpp
@@ -64,7 +64,7 @@ void CanWrite::PeriodicTask(efitick_t) {
 	updateDash(cycle);
 
 #if EFI_WIDEBAND_FIRMWARE_UPDATE
-	if (engineConfiguration->enableAemXSeries && cycle.isInterval(CI::_50ms)) {
+	if (engineConfiguration->widebandMode == WidebandMode::FOMEInternal && cycle.isInterval(CI::_50ms)) {
 		sendWidebandInfo();
 	}
 #endif

--- a/firmware/init/sensor/init_lambda.cpp
+++ b/firmware/init/sensor/init_lambda.cpp
@@ -45,7 +45,7 @@ static void initLambdaSensor(FunctionalSensor& sensor, adc_channel_e channel) {
 void initLambda() {
 
 #if EFI_CAN_SUPPORT
-	if (engineConfiguration->enableAemXSeries) {
+	if (engineConfiguration->widebandMode != WidebandMode::Analog) {
 		if (!engineConfiguration->canWriteEnabled || !engineConfiguration->canReadEnabled) {
 			firmwareError(ObdCode::OBD_PCM_Processor_Fault, "CAN read and write are required to use CAN wideband.");
 			return;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -92,7 +92,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 20019
+#define FLASH_DATA_VERSION 20020
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -687,7 +687,6 @@ bit is_enabled_spi_2
 	bit is_enabled_spi_4
 	bit pauseEtbControl;Disable the electronic throttle motor and DC idle motor for testing.\nThis mode is for testing ETB/DC idle position sensors, etc without actually driving the throttle.
 	bit alignEngineSnifferAtTDC
-	bit enableAemXSeries;AEM X-Series or rusEFI Wideband
 	bit useTableForDfcoMap,"Table","Fixed";Fixed: MAP threshold cut fuel when conditions are met\nTable: Use a curve to vary the MAP threshold based on engine RPM
 	bit postCrankingFuelUseTable,"Table","Basic";Basic: Add a fixed percent of added fuel and taper over time\nTable: Use a 3d map to set the added fuel multiplier by CLT and Runtime
 
@@ -1377,6 +1376,9 @@ uint8_t alsEtbPosition;;"", 1, 0, 0, 20000, 0
 	uint8_t autoscale ALSSkipRatio;;"", 0.1, 0, 0.1, 2, 1
 	uint8_t ALSMaxDriverThrottleIntent;;"%", 1, 0, 0, 10, 0
 	pin_input_mode_e ALSActivatePinMode;
+
+	custom WidebandMode 1 bits, S08, @OFFSET@, [0:1], @@WidebandMode_auto_enum@@
+	WidebandMode widebandMode;Select which type of wideband O2 controller you're using.
 
 	uint8_t autoscale tpsSecondaryMaximum;For Ford TPS, use 53%. For Toyota ETCS-i, use ~65%. 0 and 100 disable, <20 invalid, rest will avoid sensor averaging.;"%", 0.5, 0, 0, 100, 1
 	uint8_t autoscale ppsSecondaryMaximum;For Toyota ETCS-i, use ~69%. 0 and 100 disable, <20 invalid, rest will avoid sensor averaging.;"%", 0.5, 0, 0, 100, 1

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1377,7 +1377,7 @@ uint8_t alsEtbPosition;;"", 1, 0, 0, 20000, 0
 	uint8_t ALSMaxDriverThrottleIntent;;"%", 1, 0, 0, 10, 0
 	pin_input_mode_e ALSActivatePinMode;
 
-	custom WidebandMode 1 bits, S08, @OFFSET@, [0:1], @@WidebandMode_auto_enum@@
+	custom WidebandMode 1 bits, S08, @OFFSET@, [0:1], "Analog", "FOME Internal (CAN)", "AEM X-Series (CAN)"
 	WidebandMode widebandMode;Select which type of wideband O2 controller you're using.
 
 	uint8_t autoscale tpsSecondaryMaximum;For Ford TPS, use 53%. For Toyota ETCS-i, use ~65%. 0 and 100 disable, <20 invalid, rest will avoid sensor averaging.;"%", 0.5, 0, 0, 100, 1

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -187,8 +187,8 @@ enable2ndByteCanID = false
 
 	egoCorrectionForVeAnalyze = { 100 + fuelPidCorrection1 }
 
-	wbo1_hasFault = { enableAemXSeries && (WBO_1_faultCode >= 3) }
-	wbo2_hasFault = { enableAemXSeries && (WBO_2_faultCode >= 3) }
+	wbo1_hasFault = { widebandMode && (WBO_1_faultCode >= 3) }
+	wbo2_hasFault = { widebandMode && (WBO_2_faultCode >= 3) }
 
 [PcVariables]
 	pwmAxisLabels = bits, U08, [0:5], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1", "Aux Linear 2", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3", "Aux Linear 4", "Vehicle Speed KPH", "Oil pressure kPa", "Oil temp C"
@@ -3265,7 +3265,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "MAF 2 ADC input",						maf2AdcChannel
 
 	dialog = egoSettings_sensor,	"WB O2 sensor"
-		settingSelector = "Common O2 Controllers", { afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 }
+		settingSelector = "Common O2 Controllers", { afr_hwChannel != @@ADC_CHANNEL_NONE@@ && widebandMode == 0 }
 			settingOption = "BSPX", afr_v1=0,afr_v2=5,afr_value1=9,afr_value2=19,egoValueShift=0
 			settingOption = "Innovate", afr_v1=0,afr_v2=5,afr_value1=7.35,afr_value2=22.39,egoValueShift=0
 			settingOption = "14Point7", afr_v1=0,afr_v2=5,afr_value1=9.996,afr_value2=19.992,egoValueShift=0
@@ -3282,8 +3282,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Input channel 2",						afr_hwChannel2, { afr_hwChannel != @@ADC_CHANNEL_NONE@@ }
 		field = "Heater output",						o2heaterPin
 
-	dialog = egoSettings_CAN1, "CAN Wideband Config"
-		field = "CAN Wideband bus", widebandOnSecondBus
+	dialog = egoSettings_fomeCan, "FOME Wideband Config"
 		field = "!Please connect exactly one wideband controller before pressing these buttons!"
 		commandButton = "Update Firmware", cmd_wideband_firmare_update
 		field = "!These buttons will set ALL connected controllers to the specified index."
@@ -3293,11 +3292,11 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Force O2 sensor heating", forceO2Heating
 
 	dialog = egoSettings, "", yAxis
-		field = "Enable CAN Wideband",			enableAemXSeries, { canReadEnabled && canWriteEnabled }
-		;field = "CAN wideband type",			, { enableAemXSeries }
-		panel = egoSettings_IO1, { enableAemXSeries == 0 }, { enableAemXSeries == 0 }
-		panel = egoSettings_sensor, { afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 }, { enableAemXSeries == 0 }
-		panel = egoSettings_CAN1, { enableAemXSeries }, { enableAemXSeries }
+		field = "CAN Wideband type",			widebandMode, { canReadEnabled && canWriteEnabled }
+		field = "CAN Wideband bus",				widebandOnSecondBus, { widebandMode }, { widebandMode }
+		panel = egoSettings_IO1, { widebandMode == 0 }, { widebandMode == 0 }
+		panel = egoSettings_sensor, { afr_hwChannel != @@ADC_CHANNEL_NONE@@ && widebandMode == 0 }, { widebandMode == 0 }
+		panel = egoSettings_fomeCan, { widebandMode == 1 }, { widebandMode == 1 }
 
 ;			Engine->EGT inputs
 	dialog = egtInputs, "EGT inputs"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3292,7 +3292,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Force O2 sensor heating", forceO2Heating
 
 	dialog = egoSettings, "", yAxis
-		field = "CAN Wideband type",			widebandMode, { canReadEnabled && canWriteEnabled }
+		field = "Wideband controller type",		widebandMode, { canReadEnabled && canWriteEnabled }
 		field = "CAN Wideband bus",				widebandOnSecondBus, { widebandMode }, { widebandMode }
 		panel = egoSettings_IO1, { widebandMode == 0 }, { widebandMode == 0 }
 		panel = egoSettings_sensor, { afr_hwChannel != @@ADC_CHANNEL_NONE@@ && widebandMode == 0 }, { widebandMode == 0 }

--- a/unit_tests/tests/test_can_wideband.cpp
+++ b/unit_tests/tests/test_can_wideband.cpp
@@ -3,6 +3,8 @@
 #include "AemXSeriesLambda.h"
 
 TEST(CanWideband, AcceptFrameId0) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 
 	CANRxFrame frame;
@@ -10,20 +12,29 @@ TEST(CanWideband, AcceptFrameId0) {
 	frame.IDE = false;
 	frame.DLC = 8;
 
-	// Check that the AEM format frame is accepted
+	// Check that the AEM format frame is accepted, but not FOME
+	engineConfiguration->widebandMode = WidebandMode::AemXSeries;
 	frame.SID = 0x180;
 	EXPECT_TRUE(dut.acceptFrame(frame));
+	frame.SID = 0x190;
+	EXPECT_FALSE(dut.acceptFrame(frame));
+	frame.SID = 0x191;
+	EXPECT_FALSE(dut.acceptFrame(frame));
 
-	// Check that the rusEFI standard data is accepted
+	// Check that the FOME format frame is accepted, but not AEM
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
+	frame.SID = 0x180;
+	EXPECT_FALSE(dut.acceptFrame(frame));
 	frame.SID = 0x190;
 	EXPECT_TRUE(dut.acceptFrame(frame));
-
-	// Check that the rusEFI extended data is accepted
 	frame.SID = 0x191;
 	EXPECT_TRUE(dut.acceptFrame(frame));
+	
 }
 
 TEST(CanWideband, AcceptFrameId1) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
 	AemXSeriesWideband dut(1, SensorType::Lambda2);
 
 	CANRxFrame frame;
@@ -31,20 +42,29 @@ TEST(CanWideband, AcceptFrameId1) {
 	frame.IDE = false;
 	frame.DLC = 8;
 
-	// Check that the AEM format frame is accepted
+	// Check that the AEM format frame is accepted, but not FOME
+	engineConfiguration->widebandMode = WidebandMode::AemXSeries;
 	frame.SID = 0x181;
 	EXPECT_TRUE(dut.acceptFrame(frame));
+	frame.SID = 0x192;
+	EXPECT_FALSE(dut.acceptFrame(frame));
+	frame.SID = 0x193;
+	EXPECT_FALSE(dut.acceptFrame(frame));
 
-	// Check that the rusEFI standard data is accepted
+	// Check that the FOME format frame is accepted, but not AEM
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
+	frame.SID = 0x181;
+	EXPECT_FALSE(dut.acceptFrame(frame));
 	frame.SID = 0x192;
 	EXPECT_TRUE(dut.acceptFrame(frame));
-
-	// Check that the rusEFI extended data is accepted
 	frame.SID = 0x193;
 	EXPECT_TRUE(dut.acceptFrame(frame));
 }
 
 TEST(CanWideband, DecodeValidAemFormat) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->widebandMode = WidebandMode::AemXSeries;
+
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 	dut.Register();
 
@@ -97,9 +117,9 @@ TEST(CanWideband, DecodeValidAemFormat) {
 
 #include "wideband_firmware/for_rusefi/wideband_can.h"
 
-TEST(CanWideband, DecodeRusefiStandard)
-{
+TEST(CanWideband, DecodeRusefiStandard) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
 
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 	dut.Register();
@@ -137,9 +157,9 @@ TEST(CanWideband, DecodeRusefiStandard)
 	EXPECT_FLOAT_EQ(-1, Sensor::get(SensorType::Lambda1).value_or(-1));
 }
 
-TEST(CanWideband, DecodeRusefiStandardWrongVersion)
-{
+TEST(CanWideband, DecodeRusefiStandardWrongVersion) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->widebandMode = WidebandMode::FOMEInternal;
 
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 	dut.Register();


### PR DESCRIPTION
#597 

- Different UI gets shown depending on wideband type
- Only listen to CAN frames from the selected type (instead of all supported at the same time)

![image](https://github.com/user-attachments/assets/c3d86c02-e56a-43f2-b87d-352163755b6e)
![image](https://github.com/user-attachments/assets/3df00877-d020-4a20-bf57-3448045f8b5f)
![image](https://github.com/user-attachments/assets/0e0c5358-9ddf-46e7-a6e2-d62618b57555)
