### PR TITLE
mocked fuelflowrate sensor

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -435,6 +435,8 @@ static void updateFuelResults() {
 
 	// output channel in km
 	engine->outputChannels.distanceTraveled = 0.001f * engine->module<TripOdometer>()->getDistanceMeters();
+
+	Sensor::setMockValue(SensorType::FuelFlow, engine->module<TripOdometer>()->getConsumptionGramPerSecond(), false);
 #endif // MODULE_TRIP_ODO
 }
 

--- a/firmware/controllers/sensors/sensor_type.h
+++ b/firmware/controllers/sensors/sensor_type.h
@@ -135,6 +135,9 @@ enum class SensorType : unsigned char {
 	AuxSpeed1,
 	AuxSpeed2,
 
+	// Mock sensor fuel flow rate
+	FuelFlow,
+
 	// Let's always have all auxiliary sensors at the end - please add specific sensors above auxiliary
 
 	// Leave me at the end!

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -34,6 +34,7 @@ void initVehicleSpeedSensor();
 void initTurbochargerSpeedSensor();
 void initAuxSpeedSensors();
 void initInputShaftSpeedSensor();
+void initFuelFlowSensor();
 
 // Sensor reconfiguration
 void deinitVbatt();

--- a/firmware/init/init.mk
+++ b/firmware/init/init.mk
@@ -15,3 +15,4 @@ INIT_SRC_CPP =	$(PROJECT_DIR)/init/sensor/init_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_aux_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_turbocharger_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_input_shaft_speed_sensor.cpp \
+				$(PROJECT_DIR)/init/sensor/init_fuel_flow_rate_sensor.cpp

--- a/firmware/init/sensor/init_fuel_flow_rate_sensor.cpp
+++ b/firmware/init/sensor/init_fuel_flow_rate_sensor.cpp
@@ -1,0 +1,9 @@
+#include "pch.h"
+#include "init.h"
+#include "functional_sensor.h"
+
+static FunctionalSensor fuelFlowSensor(SensorType::FuelFlow, /* timeout = */ MS2NT(500));
+
+void initFuelFlowSensor() {
+	fuelFlowSensor.Register();
+}

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -34,6 +34,7 @@ void initNewSensors() {
 	initAuxSpeedSensors();
 
 	initFuelLevel();
+	initFuelFlowSensor();
 	initMaf();
 
 	initAuxDigital();


### PR DESCRIPTION
This allows to get the fuelflowrate in Lua without the need of using getOutput() instead via getSensor().