### PR TITLE
Small PW mass adder

### DIFF
--- a/firmware/controllers/algo/defaults/default_fuel.cpp
+++ b/firmware/controllers/algo/defaults/default_fuel.cpp
@@ -334,4 +334,5 @@ void setDefaultFuel() {
 	engineConfiguration->maxInjectorDutySustainedTimeout = 0.5f;
 
 	setLinearCurve(config->smallPulseAdderBins, 0, 3, 0.1);
+	setLinearCurve(config->smallPulseAdderMassBins, 0, 3, 0.1);
 }

--- a/firmware/controllers/algo/defaults/default_fuel.cpp
+++ b/firmware/controllers/algo/defaults/default_fuel.cpp
@@ -334,5 +334,6 @@ void setDefaultFuel() {
 	engineConfiguration->maxInjectorDutySustainedTimeout = 0.5f;
 
 	setLinearCurve(config->smallPulseAdderBins, 0, 3, 0.1);
-	setLinearCurve(config->smallPulseAdderMassBins, 0, 3, 0.1);
+	setLinearCurve(config->smallPulseAdderMassPWs, 0, 3, 0.1);
+	setLinearCurve(config->smallPulseAdderMassValues, 1, 16, 1);
 }

--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -199,6 +199,14 @@ float InjectorModelBase::getBaseDurationImpl(float fuelMassGram) const {
 
 		// large pulse uses base duration
 		break;
+	case INJ_SmallPulseAdderMass:
+		if (baseDuration < engineConfiguration->applyNonlinearBelowPulse) {
+			return interpolate2d(
+					fuelMassGram,
+					config->smallPulseAdderMassBins,
+					config->smallPulseAdderMassValues
+				);
+		}
 	case INJ_None:
 	default:
 		// no correction, use base duration

--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -203,8 +203,8 @@ float InjectorModelBase::getBaseDurationImpl(float fuelMassGram) const {
 		if (baseDuration < engineConfiguration->applyNonlinearBelowPulse) {
 			return interpolate2d(
 					fuelMassGram,
-					config->smallPulseAdderMassBins,
-					config->smallPulseAdderMassValues
+					config->smallPulseAdderMassValues,
+					config->smallPulseAdderMassBins
 				);
 		}
 	case INJ_None:

--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -204,7 +204,7 @@ float InjectorModelBase::getBaseDurationImpl(float fuelMassGram) const {
 			return interpolate2d(
 					fuelMassGram,
 					config->smallPulseAdderMassValues,
-					config->smallPulseAdderMassBins
+					config->smallPulseAdderMassPWs
 				);
 		}
 	case INJ_None:

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -581,6 +581,7 @@ typedef enum __attribute__ ((__packed__)) {
 	INJ_PolynomialAdder = 1,
 	INJ_FordModel = 2,
 	INJ_SmallPulseAdder = 3,
+	INJ_SmallPulseAdderMass = 4,
 } InjectorNonlinearMode;
 
 typedef enum __attribute__ ((__packed__)) {

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -622,6 +622,10 @@ bool validateConfig() {
 		ensureArrayIsAscending("Small PW adder", config->smallPulseAdderBins);
 	}
 
+	if (engineConfiguration->injectorNonlinearMode == INJ_SmallPulseAdderMass) {
+		ensureArrayIsAscending("Small PW adder", config->smallPulseAdderMassBins);
+	}
+
 	return true;
 }
 

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -623,7 +623,7 @@ bool validateConfig() {
 	}
 
 	if (engineConfiguration->injectorNonlinearMode == INJ_SmallPulseAdderMass) {
-		ensureArrayIsAscending("Small PW adder", config->smallPulseAdderMassBins);
+		ensureArrayIsAscending("Small PW adder", config->smallPulseAdderMassPWs);
 	}
 
 	return true;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1689,7 +1689,7 @@ uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrValues;;"multiplier", 0.02, 
 
 uint16_t[16] autoscale smallPulseAdderBins;;"ms", 0.001, 0, 0, 20, 3
 int16_t[16] autoscale smallPulseAdderValues;;"ms", 0.001, 0, -20, 20, 3
-uint16_t[16] autoscale smallPulseAdderMassBins;;"ms", 0.001, 0, 0, 20, 3
+uint16_t[16] autoscale smallPulseAdderMassPWs;;"ms", 0.001, 0, 0, 20, 3
 uint16_t[16] autoscale smallPulseAdderMassValues;;"g", 0.1, 0, 0, 200, 2
 
 uint8_t[8] autoscale minimumOilPressureBins;;"RPM", 100, 0, 0, 25000, 0

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -710,7 +710,7 @@ output_pin_e acFanPin;Optional Radiator Fan used with A/C
 
 	brain_input_pin_e vehicleSpeedSensorInputPin;
 	switch_input_pin_e clutchUpPin;Some vehicles have a switch to indicate that clutch pedal is all the way up
-	custom InjectorNonlinearMode 1 bits, U08, @OFFSET@, [0:1], "None", "Polynomial", "Ford (dual slope)", "Adder Table"
+	custom InjectorNonlinearMode 1 bits, U08, @OFFSET@, [0:2], "None", "Polynomial", "Ford (dual slope)", "Adder Table PW", "Adder Table Mass"
 	InjectorNonlinearMode injectorNonlinearMode
 	pin_input_mode_e clutchUpPinMode;
 
@@ -1689,6 +1689,8 @@ uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrValues;;"multiplier", 0.02, 
 
 uint16_t[16] autoscale smallPulseAdderBins;;"ms", 0.001, 0, 0, 20, 3
 int16_t[16] autoscale smallPulseAdderValues;;"ms", 0.001, 0, -20, 20, 3
+uint16_t[16] autoscale smallPulseAdderMassBins;;"ms", 0.001, 0, 0, 20, 3
+uint16_t[16] autoscale smallPulseAdderMassValues;;"g", 0.1, 0, 0, 200, 2
 
 uint8_t[8] autoscale minimumOilPressureBins;;"RPM", 100, 0, 0, 25000, 0
 uint8_t[8] autoscale minimumOilPressureValues;;"kPa", 10, 0, 0, 1000, 0

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -836,6 +836,13 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		xBins		= smallPulseAdderBins
 		yBins		= smallPulseAdderValues
 
+	curve = smallPulseAdderMass
+		columnLabel = "Pulsewidth", "Mass"
+		xAxis		=  0, 5, 6
+		yAxis		=  0, 100, 6
+		xBins		= smallPulseAdderMassBins
+		yBins		= smallPulseAdderMassValues
+
 [TableEditor]
 	;		table_id,	map3d_id,	"title",		page
 
@@ -2501,14 +2508,19 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Small pulse breakpoint (FUEL_BKPT)",	fordInjectorSmallPulseBreakPoint
 
 	dialog = injectorNonlinearTable, "Small Pulse Adder Table", yAxis
-		field = "Enable adder below pulse",		applyNonlinearBelowPulse
+		field = "Enable adder below pulse (PW)",		applyNonlinearBelowPulse
 		panel = smallPulseAdder
+
+	dialog = injectorNonlinearMassTable, "Small Pulse Adder Table", yAxis
+		field = "Enable adder below pulse (Mass)",		applyNonlinearBelowPulse
+		panel = smallPulseAdderMass
 
 	dialog = injectorNonlinear
 		field = "Small pulse correction mode",		injectorNonlinearMode
 		panel = injectorNonlinearPolynomial, {1}, { injectorNonlinearMode == 1 }
 		panel = injectorNonlinearFord, {1}, { injectorNonlinearMode == 2 }
 		panel = injectorNonlinearTable, {1}, { injectorNonlinearMode == 3 }
+		panel = injectorNonlinearMassTable, {1}, { injectorNonlinearMode == 4 }
 
 	dialog = testLuaOut, "Lua Out Test"
 		commandButton = "Lua Out #1",	cmd_test_lua1


### PR DESCRIPTION
Small PW mass adder (78c018a)
Add small pulse width mass adder feature

This update introduces a new injector nonlinear mode, "Small Pulse Adder Mass," into the fuel control algorithm. The change involves adding configuration support and validation for this new mode, extending the existing small pulse adder functionality to accommodate mass-based calculations.

Changes
Added a new injector nonlinear mode INJ_SmallPulseAdderMass in rusefi_enums.h.
Implemented a new configuration setting smallPulseAdderMassBins and smallPulseAdderMassValues in rusefi_config.txt to support mass-based small pulse width adjustments.
Updated validateConfig() in engine_controller.cpp to include validation for smallPulseAdderMassBins.
Extended TunerStudio configuration in tunerstudio.template.ini to include the new mass adder tables and dialogs.
Impact
Introduces a new behavioral mode for injector nonlinear adjustments based on mass rather than pulse width.
Adds dependencies on new configuration arrays for the mass adder mode.
No apparent breaking changes as this is an additive feature.
Potential performance implications if the new mode is used, depending on the complexity of the mass calculations.