### PR TITLE
Update trigger decoders readme.md

### DIFF
--- a/firmware/controllers/trigger/decoders/readme.md
+++ b/firmware/controllers/trigger/decoders/readme.md
@@ -6,7 +6,7 @@ This folder is and should not be aware of engine.h or engine_configuration.h
 
 Step 1: add into fome_config.txt
 
-Step 2: add into rusefi_enums.h, update TT_UNUSED, invoke gen_enum script
+Step 2: add into engine_types.h, update TT_UNUSED, invoke gen_enum script
 
 Step 3: get it working.
 


### PR DESCRIPTION
The original readme called out rusefi_enums.h for adding a new trigger definition, after fome_config.txt was updated and before the gen_enum script was ran. That appears to be the wrong file and should be engine_types.h <- which is different than engine.h and engine_configuration.h .