### PR TITLE
fix sdcard hangs bl

### DIFF
--- a/firmware/hw_layer/mmc_card_attach.cpp
+++ b/firmware/hw_layer/mmc_card_attach.cpp
@@ -90,6 +90,10 @@ BaseBlockDevice* initializeMmcBlockDevice() {
 		return nullptr;
 	}
 
+	if (EFI_SDC_DEVICE.state == BLK_READY) {
+		return reinterpret_cast<BaseBlockDevice*>(&EFI_SDC_DEVICE);
+	}
+
 	sdcStart(&EFI_SDC_DEVICE, &sdcConfig);
 	if (sdcConnect(&EFI_SDC_DEVICE) != HAL_SUCCESS) {
 		efiPrintf("SD card (SDMMC) failed to connect");


### PR DESCRIPTION
It was discovered recently that when a SDcard is inserted into an Atlas board and the user attemps to perform an OpenBLT update via fome console it leads to a kernel panic in ChibiOS.

After further investigation I've determined that the cause of this panic is related specifically to calling sdcStart() as second time while sdcp1 is already in BLK_READY state which violates the assert and results in a panic.

Ive attached the call stack
<img width="329" height="371" alt="obraz" src="https://github.com/user-attachments/assets/3e2bae4b-a0c8-4958-bdaa-226897abe660" />


The fix I've found simply ommits the start procedure if the device has been already started/initialized.