### PR TITLE
small fix to openblt update speed

### DIFF
--- a/firmware/hw_layer/openblt/blt_conf.h
+++ b/firmware/hw_layer/openblt/blt_conf.h
@@ -153,9 +153,9 @@
 /** \brief Configure the desired communication speed. */
 #define BOOT_COM_RS232_BAUDRATE          (115200)
 /** \brief Configure number of bytes in the target->host data packet. */
-#define BOOT_COM_RS232_TX_MAX_DATA       (200)
+#define BOOT_COM_RS232_TX_MAX_DATA       (240)
 /** \brief Configure number of bytes in the host->target data packet. */
-#define BOOT_COM_RS232_RX_MAX_DATA       (200)
+#define BOOT_COM_RS232_RX_MAX_DATA       (240)
 
 /** only USB supported, this is ignored but required */
 #define BOOT_COM_RS232_CHANNEL_INDEX 0

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -106,7 +106,7 @@ public class OpenBltFlasher {
         mCallbacks.setPhase("Program", true);
         final ProgressUpdater pu = new ProgressUpdater();
 
-        forEachFirmwareChunk(200, (Chunk c) -> {
+        forEachFirmwareChunk(199, (Chunk c) -> {
             mLoader.writeData(c.address, c.data);
 
             pu.processBytes(c.data.length);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -13,6 +13,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class OpenBltFlasher {
+    // 16 full PROGRAM_MAX packets with a 240-byte CTO, while still updating progress often.
+    private static final int PROGRAM_CHUNK_SIZE = 16 * 239;
+
     private final XcpLoader mLoader;
     private final OpenbltCallbacks mCallbacks;
 
@@ -106,7 +109,7 @@ public class OpenBltFlasher {
         mCallbacks.setPhase("Program", true);
         final ProgressUpdater pu = new ProgressUpdater();
 
-        forEachFirmwareChunk(199, (Chunk c) -> {
+        forEachFirmwareChunk(PROGRAM_CHUNK_SIZE, (Chunk c) -> {
             mLoader.writeData(c.address, c.data);
 
             pu.processBytes(c.data.length);


### PR DESCRIPTION
FOME console writes firmware in 200 byte chunks here: OpenBltFlasher.java (line 109). But Atlas/OpenBLT advertises a max programming CTO of 200, and PROGRAM_MAX payload is maxProgCto - 1, so only 199 data bytes: XcpLoader.java (line 164).

That means every 200-byte console chunk becomes:

SET_MTA
PROGRAM_MAX with 199 bytes
PROGRAM with the remaining 1 byte