### PR TITLE
F7: disable flash-while-running to fix dual-bank burn stall

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -33,6 +33,9 @@ or
 ### Added
  - Add mode for "true" wasted spark on odd fire engines (Viper V10) where companion cylinders are not exactly 360 degrees apart. Requires cam sync.
 
+### Fixed
+ - STM32F7 dual-bank ECUs no longer stall (potentially stopping the engine) when burning configuration with the engine running - configuration is now committed to flash when the engine is stopped #776
+
 ## May 2026 Release
 
 ### Breaking Changes

--- a/firmware/hw_layer/ports/stm32/stm32f7/mpu_util.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32f7/mpu_util.cpp
@@ -52,9 +52,11 @@ static DeviceType determineDevice() {
 }
 
 bool allowFlashWhileRunning() {
-	// Allow flash-while-running if dual bank mode is enabled, and we're a 2MB device (ie, no code located in second
-	// bank)
-	return determineDevice() == DeviceType::DualBank2MB;
+	// Flash-while-running is disabled on F7: erasing one bank stalls the CPU
+	// bus even while executing from the other bank (#685) - the Cortex-M7
+	// speculatively prefetches into the bank being erased. Fall back to
+	// committing configuration to flash when the engine is stopped.
+	return false;
 }
 
 // See ST AN4826


### PR DESCRIPTION
## Summary

On STM32F7, erasing a flash bank stalls the CPU bus even on dual-bank
2MB devices - the configuration `allowFlashWhileRunning()` assumes is
safe (no code in the bank being erased). During a configuration burn
the whole CPU freezes for ~700ms, which stalls the engine if it is
running.

This makes `allowFlashWhileRunning()` return `false` on F7, matching
the F4 port. Configuration writes fall back to the deferred path:
committed to flash when the engine is stopped. H7 and F4 ports are
untouched.

The exact mechanism of the bus stall is still under investigation -
disabling the Cortex-M7 I-cache and the ART accelerator/prefetch were
each tried on hardware and neither resolved it. Until a root-cause fix
exists, deferring the write is the safe behavior - it is what every
single-bank board already does.

## Testing

Proteus F7, dual-bank 2MB (F767):
- Before: burning configuration at idle freezes the CPU ~700ms and
  stalls the engine
- After: burning at idle no longer stalls the engine; the write is
  committed once the engine is stopped, and persists across a power
  cycle

Fixes #775
