### PR TITLE
Add roadside and workshop flood clear modes

### DIFF
--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -325,6 +325,7 @@ static void setDefaultEngineConfiguration() {
 	engineConfiguration->vvtOutputFrequency = 300; // VVT solenoid control
 
 	engineConfiguration->isCylinderCleanupEnabled = true;
+	engineConfiguration->isCylinderCleanupLatching = false;
 
 	engineConfiguration->auxPid[1].minValue = -50;
 	engineConfiguration->auxPid[1].maxValue = 50;

--- a/firmware/controllers/engine_cycle/prime_injection.cpp
+++ b/firmware/controllers/engine_cycle/prime_injection.cpp
@@ -32,7 +32,8 @@ static bool isPrimeInjectionPulseSkipped() {
 	}
 
 	// Skip if cylinder cleanup is active
-	return engineConfiguration->isCylinderCleanupEnabled && (Sensor::getOrZero(SensorType::Tps1) > CLEANUP_MODE_TPS);
+	return engineConfiguration->isCylinderCleanupEnabled &&
+		(Sensor::getOrZero(SensorType::DriverThrottleIntent) > CLEANUP_MODE_TPS);
 }
 
 void PrimeController::onIgnitionStateChanged(bool ignitionOn) {

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -261,9 +261,32 @@ void LimpManager::updateCutsInjectorDuty(float rpm, efitick_t nowNt, Clearable& 
 }
 
 void LimpManager::updateCutsFloodClear(Clearable& allowFuel) {
-	// If the pedal is pushed while not running, cut fuel to clear a flood condition.
-	if (!engine->rpmCalculator.isRunning() && engineConfiguration->isCylinderCleanupEnabled &&
-		Sensor::getOrZero(SensorType::DriverThrottleIntent) > CLEANUP_MODE_TPS) {
+	bool floodClearRequested = engineConfiguration->isCylinderCleanupEnabled &&
+		Sensor::getOrZero(SensorType::DriverThrottleIntent) > CLEANUP_MODE_TPS;
+
+	// Releasing the pedal (or disabling flood clear) always releases the workshop latch.
+	if (!floodClearRequested) {
+		m_floodClearLatched = false;
+		return;
+	}
+
+	if (!engineConfiguration->isCylinderCleanupLatching) {
+		// Roadside mode intentionally restores fuel if accidental combustion pushes
+		// the engine above the cranking RPM threshold.
+		m_floodClearLatched = false;
+		if (!engine->rpmCalculator.isRunning()) {
+			allowFuel.clear(ClearReason::FloodClear);
+		}
+		return;
+	}
+
+	// Workshop mode may also be used to crank a racing engine for oil pressure.
+	// Arm only while stopped/cranking so selecting this mode cannot cut a running engine.
+	if (!engine->rpmCalculator.isRunning()) {
+		m_floodClearLatched = true;
+	}
+
+	if (m_floodClearLatched) {
 		allowFuel.clear(ClearReason::FloodClear);
 	}
 }

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -163,6 +163,10 @@ private:
 
 	bool m_hadOilPressureAfterStart = false;
 
+	// Service/workshop flood clear remains active through accidental combustion
+	// until the driver releases the accelerator.
+	bool m_floodClearLatched = false;
+
 	// Ignition switch state
 	bool m_ignitionOn = false;
 

--- a/firmware/integration/fome_config.txt
+++ b/firmware/integration/fome_config.txt
@@ -930,7 +930,7 @@ bit skippedWheelOnCam,"On camshaft","On crankshaft";Where is your primary skippe
 
 	bit isInjectionEnabled
 	bit isIgnitionEnabled
-	bit isCylinderCleanupEnabled;When enabled if TPS is held above 95% no fuel is injected while cranking to clear excess fuel from the cylinders.
+	bit isCylinderCleanupEnabled;When enabled if driver throttle intent is held above 90% no fuel is injected while cranking to clear excess fuel from the cylinders.
 	bit complexWallModel,"Advanced (tables)","Basic (constants)";Should we use tables to vary tau/beta based on CLT/MAP, or just with fixed values?
 	bit alwaysInstantRpm
 	bit isMapAveragingEnabled
@@ -959,6 +959,7 @@ bit invertVvtControlExhaust,"retard","advance";If increased VVT duty cycle incre
 bit useBiQuadOnAuxSpeedSensors
 bit sdTriggerLog,"trigger","normal";'Trigger' mode will write a high speed log of trigger events (warning: uses lots of space!). 'Normal' mode will write a standard MLG of sensors, engine function, etc. similar to the one captured in TunerStudio.
 bit ALSActivateInverted
+bit isCylinderCleanupLatching,"Service / Workshop","Roadside";Roadside restores fuel if the engine reaches running RPM. Service / Workshop latches the fuel cut until the accelerator is released, so the starter can also be used to build oil pressure without enabling injection.
 
 	uint16_t engineChartSize;;"count", 1, 0, 0, 300, 0
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4164,6 +4164,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 
 	dialog = crankingAdv, "Advanced"
 		field = "Enable flood clear",				isCylinderCleanupEnabled
+		field = "Flood clear mode",				isCylinderCleanupLatching, {isCylinderCleanupEnabled}
 		field = "Enable faster engine spin-up",			isFasterEngineSpinUpEnabled
 		field = "Use Advance Corrections for cranking",	useAdvanceCorrectionsForCranking
 		field = "Use Flex Fuel cranking table",			flexCranking, { flexSensorPin }

--- a/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
+++ b/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
@@ -42,6 +42,17 @@ TEST(priming, startScheduling) {
 	ASSERT_EQ(1, engine->scheduler.size()) << "prime fuel";
 }
 
+TEST(priming, floodClearSkipsPrimeFromDriverIntent) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	engineConfiguration->isCylinderCleanupEnabled = true;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 95);
+
+	engine->module<PrimeController>()->onIgnitionStateChanged(true);
+
+	EXPECT_EQ(0, engine->scheduler.size()) << "flood clear must not schedule prime fuel";
+}
+
 TEST(priming, duration) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 

--- a/unit_tests/tests/test_limp.cpp
+++ b/unit_tests/tests/test_limp.cpp
@@ -20,6 +20,55 @@ TEST(limp, testFatalError) {
 	EXPECT_FALSE(dut.allowTriggerInput());
 }
 
+TEST(limp, floodClearRoadsideAllowsAccidentalStart) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	LimpManager dut;
+
+	engineConfiguration->isCylinderCleanupEnabled = true;
+	engineConfiguration->isCylinderCleanupLatching = false;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 95);
+
+	engine->rpmCalculator.setRpmValue(300);
+	dut.updateState(300, getTimeNowNt());
+	ASSERT_FALSE(dut.allowInjection());
+	EXPECT_EQ(ClearReason::FloodClear, dut.allowInjection().reason);
+
+	// Roadside mode restores fuel when residual fuel causes the engine to cross
+	// the configured cranking RPM threshold.
+	engine->rpmCalculator.setRpmValue(engineConfiguration->cranking.rpm);
+	dut.updateState(engineConfiguration->cranking.rpm, getTimeNowNt());
+	EXPECT_TRUE(dut.allowInjection());
+}
+
+TEST(limp, floodClearWorkshopLatchesUntilPedalRelease) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	LimpManager dut;
+
+	engineConfiguration->isCylinderCleanupEnabled = true;
+	engineConfiguration->isCylinderCleanupLatching = true;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 95);
+
+	engine->rpmCalculator.setRpmValue(300);
+	dut.updateState(300, getTimeNowNt());
+	ASSERT_FALSE(dut.allowInjection());
+	EXPECT_EQ(ClearReason::FloodClear, dut.allowInjection().reason);
+
+	// Accidental combustion must not restore fuel in workshop mode.
+	engine->rpmCalculator.setRpmValue(engineConfiguration->cranking.rpm);
+	dut.updateState(engineConfiguration->cranking.rpm, getTimeNowNt());
+	ASSERT_FALSE(dut.allowInjection());
+	EXPECT_EQ(ClearReason::FloodClear, dut.allowInjection().reason);
+
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 0);
+	dut.updateState(engineConfiguration->cranking.rpm, getTimeNowNt());
+	EXPECT_TRUE(dut.allowInjection());
+
+	// Workshop mode cannot arm while the engine is already running.
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 95);
+	dut.updateState(engineConfiguration->cranking.rpm, getTimeNowNt());
+	EXPECT_TRUE(dut.allowInjection());
+}
+
 TEST(limp, revLimit) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 


### PR DESCRIPTION
## Summary

- add selectable Roadside and Service / Workshop flood-clear modes
- keep the existing Roadside behavior, which restores fuel once running RPM is reached
- latch the Workshop fuel cut through accidental combustion until the accelerator is released
- skip the priming pulse using `DriverThrottleIntent`, including DBW applications
- expose the mode in TunerStudio without changing the persistent configuration layout

## Motivation

Flood clear was conditioned directly on `!isRunning()`. Residual fuel could therefore produce an accidental combustion event, push the engine over the cranking RPM threshold, and immediately re-enable injection.

Roadside mode intentionally preserves that behavior so the engine may recover and start. Service / Workshop mode keeps injection disabled after it has been armed, allowing cylinders to be cleared or a racing engine to be cranked for oil pressure. Releasing the accelerator clears the latch, and the mode cannot arm on an already-running engine.

The new setting occupies the previously unused bit 31 at offset 1064, so no existing fields move and the configuration size is unchanged. Roadside remains the default.

## Validation

- `make -j4` in `unit_tests`
- `./build/fome_test '--gtest_filter=limp.*:priming.*'`
- 12/12 selected tests passed
