### PR TITLE
Make Hella PULS oil level sensor usable

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -37,6 +37,7 @@ or
  - IMU data (lateral/longitudinal acceleration and yaw rate) from the BMW E90 MK60e1/MK60e5 DSC/ABS module
  - New VVT mode "Honda K24Z Exhaust" for the three-tooth unevenly spaced exhaust cam wheel used on the K24Z, which differs from the 4+1 wheel of earlier K series engines. This pattern is used by K series engines that use a 60-2 crank pattern.
  - CAN wideband controllers now report "time since last CAN frame received" and a TunerStudio alive indicator for all 4 wideband channels (previously only 2 had live data at all), so a dead/disconnected controller can be spotted even when its lambda reading is invalid
+ - Support for Hella PULS ultrasonic oil level sensors (6PR 009 622-041 and 6PR 009 622-051). A decoder for these sensors has existed since 2023 but was never configurable or connected to a sensor channel - it can now be assigned an input pin in TunerStudio and reports both oil level and oil temperature. Oil temperature is only published if no analog oil temperature sender is configured, which continues to take priority.
 
 ### Fixed
  - STM32F7 dual-bank ECUs no longer stall (potentially stopping the engine) when burning configuration with the engine running - configuration is now committed to flash when the engine is stopped #776

--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -293,4 +293,6 @@ struct_no_prefix output_channels_s
 
 	uint16_t[12 iterate] cylinderRpm;;"rpm", 1, 0, 0, 0, 0
 	int8_t[12 iterate] cylinderRpmDelta;;"rpm", 1, 0, 0, 0, 0
+
+	uint16_t autoscale oilLevel;@@GAUGE_NAME_OIL_LEVEL@@;"mm", 0.1, 0, 0, 0, 1
 end_struct

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -375,6 +375,8 @@ static void updateMiscSensors() {
 	engine->outputChannels.auxSpeed1 = Sensor::getOrZero(SensorType::AuxSpeed1);
 	engine->outputChannels.auxSpeed2 = Sensor::getOrZero(SensorType::AuxSpeed2);
 
+	engine->outputChannels.oilLevel = Sensor::getOrZero(SensorType::OilLevel);
+
 #if HAL_USE_ADC
 	engine->outputChannels.internalMcuTemperature =
 			Sensor::get(SensorType::EcuInternalTemperature).value_or(getMCUInternalTemperature());

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -584,6 +584,17 @@ typedef enum __attribute__((__packed__)) {
 	INJ_SmallPulseAdder = 3,
 } InjectorNonlinearMode;
 
+/**
+ * Hella PULS ultrasonic oil level sensors share a signal format, but differ in
+ * measurement range. The level reported at 20%/80% duty depends on the variant.
+ */
+typedef enum __attribute__((__packed__)) {
+	// 6PR 009 622-041: 5v supply, 45mm range, reads 20.9mm to 65.9mm
+	HELLA_OIL_LEVEL_45MM = 0,
+	// 6PR 009 622-051: 12v supply, 129mm static range, reads 18.0mm to 147.0mm
+	HELLA_OIL_LEVEL_129MM = 1,
+} hella_oil_level_variant_e;
+
 typedef enum __attribute__((__packed__)) {
 	HPFP_CAM_NONE = 0,
 	HPFP_CAM_IN1 = 1,

--- a/firmware/controllers/sensors/hella_oil_level.cpp
+++ b/firmware/controllers/sensors/hella_oil_level.cpp
@@ -4,13 +4,33 @@
 
 #include "digital_input_exti.h"
 
+// Pulse width at the bottom and top of any measured range: 20% and 80% of the 110ms window
+static constexpr float minPulseMs = 22;
+static constexpr float maxPulseMs = 88;
+
+// Temperature range is the same for every variant
+static constexpr float minTempC = -40;
+static constexpr float maxTempC = 160;
+
 static void hellaSensorExtiCallback(void* arg, efitick_t nowNt) {
 	reinterpret_cast<HellaOilLevelSensor*>(arg)->onEdge(nowNt);
 }
 
-void HellaOilLevelSensor::init(brain_pin_e pin) {
+void HellaOilLevelSensor::init(brain_pin_e pin, hella_oil_level_variant_e variant) {
 	if (!isBrainPinValid(pin)) {
 		return;
+	}
+
+	switch (variant) {
+		case HELLA_OIL_LEVEL_129MM:
+			m_levelAtMinPulse = 18.0f;
+			m_levelAtMaxPulse = 147.0f;
+			break;
+		case HELLA_OIL_LEVEL_45MM:
+		default:
+			m_levelAtMinPulse = 20.9f;
+			m_levelAtMaxPulse = 65.9f;
+			break;
 	}
 
 	m_pin = pin;
@@ -21,6 +41,35 @@ void HellaOilLevelSensor::init(brain_pin_e pin) {
 #endif // EFI_PROD_CODE
 
 	Register();
+
+	// Oil temperature may already be provided by an analog sender. Registering it twice is a
+	// firmware error, so leave the existing sensor alone and report level only.
+	if (!Sensor::hasSensor(m_temperature.type())) {
+		m_temperatureRegistered = m_temperature.Register();
+	}
+}
+
+void HellaOilLevelSensor::deInit() {
+	if (!isBrainPinValid(m_pin)) {
+		// Never initialized, so there's nothing of ours to tear down. Bail out rather than
+		// clearing registry slots we don't own.
+		return;
+	}
+
+#if EFI_PROD_CODE
+	efiExtiDisablePin(m_pin);
+#endif // EFI_PROD_CODE
+
+	m_pin = Gpio::Unassigned;
+	m_nextPulse = NextPulse::None;
+
+	unregister();
+
+	// Only give up the temperature slot if it was ours to begin with
+	if (m_temperatureRegistered) {
+		m_temperature.unregister();
+		m_temperatureRegistered = false;
+	}
 }
 
 void HellaOilLevelSensor::onEdge(efitick_t nowNt) {
@@ -38,6 +87,7 @@ void HellaOilLevelSensor::onEdge(efitick_t nowNt, bool value) {
 
 		if (timeBetweenPulses > 0.89 * 0.780 && timeBetweenPulses < 1.11 * 0.780) {
 			// 780ms nominal between Diag and next Temp pulse start, +-10%
+			// (68.2ms diag pulse plus the 711.8ms idle remainder of the 1000ms frame)
 
 			// This was the "long gap" break, next pulse is temperature.
 			m_nextPulse = NextPulse::Temp;
@@ -65,43 +115,30 @@ void HellaOilLevelSensor::onEdge(efitick_t nowNt, bool value) {
 		// Stop timing at the falling edge
 		float lastPulseMs = 1000 * m_pulseTimer.getElapsedSeconds(nowNt);
 
+		// Data pulses are 22ms to 88ms, and the fixed diagnostic pulse is 68.2ms. All time
+		// signals carry a +-10% tolerance, so allow margin beyond the nominal range before
+		// deciding a pulse is bogus. Anything outside means we lost the plot - resync.
 		if (lastPulseMs > 100 || lastPulseMs < 20) {
-			// Impossibly short or long pulse, something went wrong
 			m_nextPulse = NextPulse::None;
 			return;
 		}
 
-		if (m_nextPulse == NextPulse::Diag) {
-			// TODO: decode diag pulse?
-			return;
-		} else if (m_nextPulse == NextPulse::Temp) {
-			// 22ms = Short circuit temp sensor
-			// 23ms = -40C
-			// 87ms = 160C
-			// 88ms = Temp sensor defective
-
-			if (lastPulseMs < 22.8) {
-				// Short circuit
-				// invalidate(UnexpectedCode::Low);
-			} else if (lastPulseMs > 87.2) {
-				// Defective
-				// invalidate(UnexpectedCode::High);
-			} else {
-				// float tempC = interpolateClamped(23, -40, 87, 160, lastPulseMs);
-				// setValidValue(tempC, nowNt);
+		switch (m_nextPulse) {
+			case NextPulse::Temp: {
+				float tempC = interpolateClamped(minPulseMs, minTempC, maxPulseMs, maxTempC, lastPulseMs);
+				m_temperature.setValidValue(tempC, nowNt);
+				break;
 			}
-		} else if (m_nextPulse == NextPulse::Level) {
-			// 22ms = Unreliable signal
-			// 23ms = level 0mm
-			// 87.86ms = level 150mm
-
-			if (lastPulseMs < 22.8f) {
-				// Unreliable
-				invalidate(UnexpectedCode::Low);
-			} else {
-				float levelMm = interpolateClamped(23, 0, 87.86, 150, lastPulseMs);
+			case NextPulse::Level: {
+				float levelMm =
+						interpolateClamped(minPulseMs, m_levelAtMinPulse, maxPulseMs, m_levelAtMaxPulse, lastPulseMs);
 				setValidValue(levelMm, nowNt);
+				break;
 			}
+			default:
+				// Diagnostic pulse is fixed width and carries no measurement, and without sync
+				// we don't know what this pulse means. Either way, nothing to record.
+				break;
 		}
 	}
 }

--- a/firmware/controllers/sensors/hella_oil_level.h
+++ b/firmware/controllers/sensors/hella_oil_level.h
@@ -2,18 +2,47 @@
 
 #include "stored_value_sensor.h"
 
+/**
+ * Hella PULS ultrasonic oil level/temperature sensor.
+ *
+ * The sensor emits a repeating sequence of three positive pulses on a single open collector
+ * output. Pulse width encodes the value, and the position in the sequence selects which
+ * quantity is being reported:
+ *
+ *   T1 (temperature) -> 110ms -> T2 (level) -> 110ms -> T3 (diagnostic) -> 780ms -> repeat
+ *
+ * Pulse widths run from 22ms (20% of the 110ms window) to 88ms (80%), spanning the full
+ * measurement range of whichever quantity that pulse carries. The 68.2ms diagnostic pulse
+ * is fixed width and is not currently decoded.
+ *
+ * Sync is acquired on the 780ms rising-edge-to-rising-edge gap, which only ever follows the
+ * diagnostic pulse, so the pulse after it is unambiguously temperature.
+ */
 class HellaOilLevelSensor : public StoredValueSensor {
 public:
-	HellaOilLevelSensor(SensorType type)
-		: StoredValueSensor(type, MS2NT(2000)) {}
+	HellaOilLevelSensor(SensorType levelType, SensorType temperatureType)
+		: StoredValueSensor(levelType, MS2NT(2000))
+		, m_temperature(temperatureType, MS2NT(2000)) {}
 
-	void init(brain_pin_e pin);
+	void init(brain_pin_e pin, hella_oil_level_variant_e variant);
+	void deInit();
 
 	void onEdge(efitick_t nowNt);
 	void onEdge(efitick_t nowNt, bool value);
 
 private:
+	// Temperature shares the same signal, so it is driven from the same edge callback
+	StoredValueSensor m_temperature;
+
+	// Whether we own the temperature registration - an analog sender may have claimed it first
+	bool m_temperatureRegistered = false;
+
 	brain_pin_e m_pin = Gpio::Unassigned;
+
+	// Level reported at minimum (22ms) and maximum (88ms) pulse width, in millimeters.
+	// Set from the configured sensor variant.
+	float m_levelAtMinPulse = 0;
+	float m_levelAtMaxPulse = 0;
 
 	// Measures the width of positive pulses (rising -> falling)
 	Timer m_pulseTimer;

--- a/firmware/controllers/sensors/sensor_type.h
+++ b/firmware/controllers/sensors/sensor_type.h
@@ -33,6 +33,8 @@ enum class SensorType : unsigned char {
 
 	OilPressure,
 	OilTemperature,
+	// Height of the oil column in the sump, in millimeters
+	OilLevel,
 
 	FuelPressureLow,  // in kPa
 	FuelPressureHigh, // in kPa

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -34,6 +34,7 @@ void initAuxSensors();
 void initVehicleSpeedSensor();
 void initTurbochargerSpeedSensor();
 void initAuxSpeedSensors();
+void initHellaOilLevel();
 
 // Sensor reconfiguration
 void deinitVbatt();
@@ -47,3 +48,4 @@ void deInitVehicleSpeedSensor();
 void deinitTurbochargerSpeedSensor();
 void deinitMap();
 void deinitAuxSpeedSensors();
+void deInitHellaOilLevel();

--- a/firmware/init/init.mk
+++ b/firmware/init/init.mk
@@ -14,3 +14,4 @@ INIT_SRC_CPP =	$(PROJECT_DIR)/init/sensor/init_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_vehicle_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_aux_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_turbocharger_speed_sensor.cpp \
+				$(PROJECT_DIR)/init/sensor/init_hella_oil_level.cpp \

--- a/firmware/init/sensor/init_hella_oil_level.cpp
+++ b/firmware/init/sensor/init_hella_oil_level.cpp
@@ -1,0 +1,15 @@
+#include "pch.h"
+
+#include "init.h"
+#include "hella_oil_level.h"
+
+// One sensor drives both channels - level and temperature come from the same signal
+static HellaOilLevelSensor hellaOilLevel(SensorType::OilLevel, SensorType::OilTemperature);
+
+void initHellaOilLevel() {
+	hellaOilLevel.init(engineConfiguration->hellaOilLevelPin, engineConfiguration->hellaOilLevelVariant);
+}
+
+void deInitHellaOilLevel() {
+	hellaOilLevel.deInit();
+}

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -68,6 +68,7 @@ void stopSensors() {
 	deinitTurbochargerSpeedSensor();
 	deinitAuxSpeedSensors();
 	deinitMap();
+	deInitHellaOilLevel();
 }
 
 void reconfigureSensors() {
@@ -81,6 +82,9 @@ void reconfigureSensors() {
 	initAuxSensors();
 	initVehicleSpeedSensor();
 	initTurbochargerSpeedSensor();
+	// Must come after initThermistors() - an analog oil temperature sender takes priority
+	// over the temperature channel of the Hella sensor.
+	initHellaOilLevel();
 }
 
 // Mocking/testing helpers

--- a/firmware/integration/fome_config.txt
+++ b/firmware/integration/fome_config.txt
@@ -1486,6 +1486,10 @@ pin_input_mode_e[LUA_DIGITAL_INPUT_COUNT iterate] luaDigitalInputPinModes;
 
 	torque_limiter_cfg[TORQUE_LIMITER_COUNT iterate] torqueLimiters;
 
+	brain_input_pin_e hellaOilLevelPin;Hella PULS ultrasonic oil level/temperature sensor, single wire PWM output. Requires a 1.6-10k pullup to the sensor supply voltage.;
+	custom hella_oil_level_variant_e 1 bits, U08, @OFFSET@, [0:0], "45mm (6PR 009 622-041)", "129mm (6PR 009 622-051)"
+	hella_oil_level_variant_e hellaOilLevelVariant;Which Hella sensor variant is installed - they share a signal format but report different measurement ranges.;
+
 ! end of engine_configuration_s
 end_struct
 

--- a/firmware/integration/fome_config_shared.txt
+++ b/firmware/integration/fome_config_shared.txt
@@ -101,6 +101,7 @@
 
 #define GAUGE_NAME_OIL_PRESSURE "Oil Pressure"
 #define GAUGE_NAME_OIL_TEMPERATURE "Oil Temperature"
+#define GAUGE_NAME_OIL_LEVEL "Oil Level"
 
 #define GAUGE_NAME_ECU_TEMPERATURE "ECU temperature"
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1468,6 +1468,7 @@ gaugeCategory = Sensors - Extra 1
 	lowFuelPressureGauge = lowFuelPressure, @@GAUGE_NAME_FUEL_PRESSURE_LOW@@, "kPa", 0, 700, 0, 0, 700, 700, 1, 0
 	flexPercentGauge = flexPercent, @@GAUGE_NAME_FLEX@@, "%", 0, 100, 0, 0, 100, 100, 0, 0
 	fuelTankLevelGauge	= fuelTankLevel,"Fuel level",			"%",		0,		100,		10,	20,	100,	100,	1,	1
+	oilLevelGauge		= oilLevel,	@@GAUGE_NAME_OIL_LEVEL@@,		"mm",		0,		150,		0,	0,	150,	150,	1,	1
 	AuxL1Gauge		= auxLinear1,	@@GAUGE_NAME_AUX_LINEAR_1@@, "", -100, 100, -100, -100, 100, 100, 2, 2
 	AuxL2Gauge		= auxLinear2,	@@GAUGE_NAME_AUX_LINEAR_2@@, "", -100, 100, -100, -100, 100, 100, 2, 2
 	AuxL3Gauge		= auxLinear3,	@@GAUGE_NAME_AUX_LINEAR_3@@, "", -100, 100, -100, -100, 100, 100, 2, 2
@@ -2036,6 +2037,7 @@ menuDialog = main
 		subMenu = fuelPressureSensor,		"Fuel pressure"
 		subMenu = fuelTempSensor,			"Fuel temp sensor"
 		subMenu = fuelLevelDialog,			"Fuel level sensor"
+		subMenu = hellaOilLevelDialog,		"Hella oil level sensor"
 		subMenu = ambientTempSensor,		"Ambient temp sensor"
 		subMenu = compressorDischargeTemperature,	"Compressor discharge temp"
 		subMenu = egtInputs,				"EGT" @@if_ts_show_egt
@@ -3000,6 +3002,16 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "Input channel",						fuelLevelSensor
 		panel = fuelLevelCurve
 
+	dialog = hellaOilLevelDialog,			"Hella Oil Level Sensor"
+		field = "Hella PULS sensors report oil level and oil temperature as a repeating"
+		field = "pulse train on a single wire. Needs a 1.6-10k pullup to the sensor supply."
+		field = ""
+		field = "Input channel",						hellaOilLevelPin
+		field = "Sensor variant",						hellaOilLevelVariant, { hellaOilLevelPin != @@ADC_CHANNEL_NONE@@ }
+		field = ""
+		field = "Oil temperature is taken from this sensor unless an analog oil"
+		field = "temperature sender is also configured, which takes priority."
+
 ;
 ; allXXX sections allows a quick overview of used I/O in order to address conflicts mostly, not really to
 ; configure the features.
@@ -3023,6 +3035,7 @@ dialog = launch_control_stateDialog, "launch_control_state"
 		field = "MAP ADC input",						map_sensor_hwChannel
 		field = "MAP 2 ADC input",						map2HwChannel
 		field = "Fuel Level input",					fuelLevelSensor
+		field = "Oil Level input",					hellaOilLevelPin
 		field = "Vehicle Speed input",				vehicleSpeedSensorInputPin
 		field = "Clutch Down input",					clutchDownPin
 		field = "Clutch Up input",						clutchUpPin

--- a/unit_tests/tests/sensor/test_hella_oil_level.cpp
+++ b/unit_tests/tests/sensor/test_hella_oil_level.cpp
@@ -1,0 +1,167 @@
+#include "pch.h"
+
+#include "hella_oil_level.h"
+
+// The sensor emits a 1000ms frame:
+//   T1 (temperature) -> 110ms -> T2 (level) -> 110ms -> T3 (diag, 68.2ms) -> 780ms -> repeat
+// Pulse width runs 22ms (bottom of range) to 88ms (top of range). All times are rising edge
+// to rising edge, so a pulse "slot" is 110ms regardless of how wide the pulse itself is.
+static constexpr float slotMs = 110;
+static constexpr float diagPulseMs = 68.2;
+static constexpr float breakMs = 780;
+
+class HellaOilLevelTest : public ::testing::Test {
+public:
+	HellaOilLevelTest()
+		: dut(SensorType::OilLevel, SensorType::OilTemperature) {}
+
+	// Feed one pulse: rising edge, hold high for widthMs, falling edge.
+	// Then idle until the next rising edge is slotMs after this one.
+	void pulse(float widthMs, float untilNextRiseMs) {
+		dut.onEdge(getTimeNowNt(), true);
+		advanceMs(widthMs);
+		dut.onEdge(getTimeNowNt(), false);
+		advanceMs(untilNextRiseMs - widthMs);
+	}
+
+	// One complete frame with the given temperature and level pulse widths
+	void frame(float tempPulseMs, float levelPulseMs) {
+		pulse(tempPulseMs, slotMs);
+		pulse(levelPulseMs, slotMs);
+		pulse(diagPulseMs, breakMs);
+	}
+
+	void advanceMs(float ms) {
+		m_eth.moveTimeForwardSec(ms / 1000);
+	}
+
+	// Each test registers a fresh sensor into the global registry, so clear it out
+	// explicitly rather than relying on member destruction order.
+	void TearDown() override {
+		Sensor::resetRegistry();
+	}
+
+	EngineTestHelper m_eth{engine_type_e::TEST_ENGINE};
+	HellaOilLevelSensor dut;
+};
+
+// 45mm variant (6PR 009 622-041) reads 20.9mm at 22ms and 65.9mm at 88ms
+TEST_F(HellaOilLevelTest, level45mmVariant) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	// Nothing decoded yet - we haven't acquired sync
+	EXPECT_FALSE(Sensor::get(SensorType::OilLevel).Valid);
+
+	// First frame acquires sync on the break, so the level pulse of the *second* frame
+	// is the first one we can decode.
+	frame(55, 55);
+
+	frame(55, 22);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 20.9f, 0.1f);
+
+	frame(55, 88);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 65.9f, 0.1f);
+
+	// Midpoint: 55ms is halfway between 22 and 88, so halfway between 20.9 and 65.9
+	frame(55, 55);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 43.4f, 0.1f);
+}
+
+// 129mm variant (6PR 009 622-051) reads 18.0mm at 22ms and 147.0mm at 88ms
+TEST_F(HellaOilLevelTest, level129mmVariant) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_129MM);
+
+	frame(55, 55);
+
+	frame(55, 22);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 18.0f, 0.1f);
+
+	frame(55, 88);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 147.0f, 0.1f);
+}
+
+// Temperature spans -40C to 160C for every variant
+TEST_F(HellaOilLevelTest, temperature) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	frame(55, 55);
+
+	frame(22, 55);
+	EXPECT_NEAR(Sensor::get(SensorType::OilTemperature).value_or(0), -40.0f, 0.1f);
+
+	frame(88, 55);
+	EXPECT_NEAR(Sensor::get(SensorType::OilTemperature).value_or(0), 160.0f, 0.1f);
+
+	// Midpoint of 22..88 is 55ms, midpoint of -40..160 is 60C
+	frame(55, 55);
+	EXPECT_NEAR(Sensor::get(SensorType::OilTemperature).value_or(0), 60.0f, 0.1f);
+}
+
+// Level and temperature must not be confused with one another
+TEST_F(HellaOilLevelTest, decodesBothChannelsIndependently) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	frame(55, 55);
+	frame(22, 88);
+
+	EXPECT_NEAR(Sensor::get(SensorType::OilTemperature).value_or(0), -40.0f, 0.1f);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 65.9f, 0.1f);
+}
+
+// Out-of-range pulse widths mean we lost the plot - drop sync rather than report garbage
+TEST_F(HellaOilLevelTest, implausiblePulseDropsSync) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	frame(55, 55);
+	frame(55, 22);
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 20.9f, 0.1f);
+
+	// A 5ms pulse is impossibly short. It resets the state machine, so the level pulse
+	// that follows in this frame is not trusted and the reading must not update.
+	pulse(5, slotMs);
+	pulse(88, slotMs);
+	pulse(diagPulseMs, breakMs);
+
+	// Still the old value, not the 65.9mm that an 88ms pulse would have decoded to
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 20.9f, 0.1f);
+}
+
+// Signal loss must invalidate rather than latch the last reading forever
+TEST_F(HellaOilLevelTest, timesOutWhenSignalStops) {
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	frame(55, 55);
+	frame(55, 55);
+	EXPECT_TRUE(Sensor::get(SensorType::OilLevel).Valid);
+	EXPECT_TRUE(Sensor::get(SensorType::OilTemperature).Valid);
+
+	// Sensor updates once per second, and the timeout is 2 seconds
+	advanceMs(2500);
+
+	EXPECT_FALSE(Sensor::get(SensorType::OilLevel).Valid);
+	EXPECT_FALSE(Sensor::get(SensorType::OilTemperature).Valid);
+}
+
+// An analog oil temperature sender takes priority - registering twice is a firmware error
+TEST_F(HellaOilLevelTest, doesNotStealTemperatureFromAnalogSender) {
+	StoredValueSensor analogOilTemp(SensorType::OilTemperature, MS2NT(1000));
+	ASSERT_TRUE(analogOilTemp.Register());
+
+	dut.init(Gpio::A0, HELLA_OIL_LEVEL_45MM);
+
+	// Level is ours, temperature belongs to the analog sender
+	frame(55, 55);
+	frame(88, 22);
+
+	EXPECT_NEAR(Sensor::get(SensorType::OilLevel).value_or(-1), 20.9f, 0.1f);
+
+	// The analog sender still owns this channel, so our 88ms pulse (160C) was not published
+	analogOilTemp.setValidValue(75, getTimeNowNt());
+	EXPECT_NEAR(Sensor::get(SensorType::OilTemperature).value_or(0), 75.0f, 0.1f);
+
+	// Tearing down must not evict the analog sender
+	dut.deInit();
+	EXPECT_TRUE(Sensor::hasSensor(SensorType::OilTemperature));
+
+	analogOilTemp.unregister();
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -105,6 +105,7 @@ TESTS_SRC_CPP = \
 	tests/test_can_wideband.cpp \
 	tests/test_hellen_board_id.cpp \
 	tests/sensor/test_frequency_sensor.cpp \
+	tests/sensor/test_hella_oil_level.cpp \
 	tests/sensor/test_turbocharger_speed_converter.cpp \
 	tests/sensor/test_vehicle_speed_converter.cpp \
 	tests/actuators/test_antilag.cpp \


### PR DESCRIPTION
## What this does

Makes the Hella PULS ultrasonic oil level sensor usable. The decoder has existed since 89945206 ("stub hella level sensor", Sept 2023) but was never reachable: `HellaOilLevelSensor` is compiled via `sensors.mk` yet never instantiated, there is no `OilLevel` sensor type, no configuration field, and no way to assign it a pin. This wires it up and corrects the decode.

Tested against a `6PR 009 622-041` on the bench (Datsun 260Z / VH41DE project), cross-checked against the Hella datasheet and a known-working Arduino decoder for the same part.

## Changes

**Wiring up**
- New `SensorType::OilLevel`, `oilLevel` output channel, and a TunerStudio dialog under Sensors with input pin and variant selection
- `init_hella_oil_level.cpp` hooked into `reconfigureSensors()` / `stopSensors()`
- `deInit()` so the sensor survives reconfiguration

**Decode corrections**
- Level scale was `0mm at 23ms -> 150mm at 87.86ms`, which matches no shipping variant. Correct values come from the datasheet transfer function `Level = [(T2/T - 0.2) x k + offset] x T/110 + 5.34`, which resolves to:
  - `6PR 009 622-041` (5v, 45mm range): **20.9mm to 65.9mm**
  - `6PR 009 622-051` (12v, 129mm range): **18.0mm to 147.0mm**
  
  Selected by a new `hellaOilLevelVariant` config field rather than hardcoded, since the two parts differ only in scaling.
- Temperature was computed and then discarded (`setValidValue` commented out). Now published to `SensorType::OilTemperature`, `-40C` to `160C`.
- Data endpoints moved from 23/87ms to **22/88ms**. The datasheet defines 20% (22ms) and 80% (88ms) as the ends of the measuring range, not fault codes. The old guards rejected anything below 22.8ms or above 87.2ms, so legitimate full-scale readings were being thrown away — and with the datasheet's ±10% tolerance on all time signals, a nominal 22ms pulse can arrive anywhere from 19.8 to 24.2ms, which put the 22.8ms threshold inside the valid band.

Sync timing (780ms rising-to-rising break, 110ms inter-pulse) is unchanged — it was already correct. For anyone checking against the datasheet, 780ms is the 68.2ms diagnostic pulse plus the 711.8ms idle remainder of the 1000ms frame.

## Two latent bugs fixed along the way

- **Duplicate registration was a hard fault.** `OilTemperature` is already registered by `init_thermistors.cpp` when an analog sender is configured, and `SensorRegistryEntry::Register()` raises a `firmwareError` on a second registration. Anyone running both would have faulted the ECU on boot. The Hella temperature channel now checks `hasSensor()` first and yields to the analog sender, which keeps priority.
- **`unregister()` does not check ownership** — it clears the slot unconditionally. Tearing down the Hella sensor would therefore have evicted an analog sender's `OilTemperature` registration. Now tracked explicitly, and `deInit()` returns early if the sensor was never initialized.

## Testing

`unit_tests/tests/sensor/test_hella_oil_level.cpp` — 7 tests driving synthetic pulse trains through the two-argument `onEdge(nowNt, value)` overload:

- level scaling at both ends and midpoint, for both variants
- temperature scaling at both ends and midpoint
- level and temperature are not confused with one another
- an implausible pulse width drops sync and does not update the reading
- signal loss invalidates via the 2 second timeout rather than latching
- an analog oil temperature sender keeps ownership, and teardown does not evict it

## Notes for review

- Generated files are deliberately not included, per the note in `fome_config.txt` and the `gen-configs` workflow. This means `auto_generated_sensor.h` is missing a case for the new enum value until that workflow runs, which produces a `-Wswitch` warning; it is not fatal, and name lookup (`findSensorByName`) will return `"unknown"` for `OilLevel` until regeneration.
- `fome_config.txt` has no `mainUnusedEnd[]` padding to consume, so the two new fields are appended at the end of `engine_configuration_s` where they do not shift the offset of any existing field.
- **On atomicity:** CONTRIBUTING.md asks for one PR per distinct change, and this arguably bundles a feature with two bug fixes. I have kept it together because the code is currently unreachable — there is no working configuration to split toward, and the scale fix and temperature channel are only observable once the sensor can be assigned a pin at all. Happy to break it up if you would prefer.
