### PR TITLE
Potential resource leak was fixed in LuaHandle

### DIFF
--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -157,12 +157,12 @@ static void loadLibraries(LuaHandle& ls) {
 }
 
 static LuaHandle setupLuaState(lua_Alloc alloc) {
-	LuaHandle ls = lua_newstate(alloc, NULL);
+	LuaHandle ls{lua_newstate(alloc, NULL)};
 
 	if (!ls) {
 		firmwareError("Failed to start Lua interpreter");
 
-		return nullptr;
+		return ls;
 	}
 
 	lua_atpanic(ls, [](lua_State* l) {

--- a/firmware/controllers/lua/rusefi_lua.h
+++ b/firmware/controllers/lua/rusefi_lua.h
@@ -8,7 +8,9 @@ class LuaHandle final {
 public:
 	LuaHandle()
 		: LuaHandle(nullptr) {}
-	LuaHandle(lua_State* ptr)
+
+	// Explicit avoids unnecessary capturing
+	explicit LuaHandle(lua_State* ptr)
 		: m_ptr(ptr) {}
 
 	// Don't allow copying!
@@ -23,9 +25,12 @@ public:
 
 	// Move assignment operator
 	LuaHandle& operator=(LuaHandle&& rhs) {
-		m_ptr = rhs.m_ptr;
-		rhs.m_ptr = nullptr;
-
+		if (this != &rhs) {
+			// Swapping pointer is neccessary, otherwise leak
+			auto temp = m_ptr;
+			m_ptr = rhs.m_ptr;
+			rhs.m_ptr = temp;
+		}
 		return *this;
 	}
 


### PR DESCRIPTION
Move assingment loses lua_State pointer + explicit constructor to avoid extra captures. More detailed comments here https://github.com/rusefi/rusefi/pull/10154

UPD: attached comments from link:

This PR is related with small improvements for LuaHandle:

Usually it's good idea to have explicit constructor in order to prevent any accidential captures of native handles.
Move assingment had potential memory leak. Currently this operator is not used in codebase, but I decided to fix it just in case.
P.S. These fixes lead me to the thought to create special allocator to check potential mem leaks in unit tests. Is it good idea to cover such cases? I may add it later in separate PR

Actually potential memory leak is in original move assignment constructor. If we have code like this 

```cpp
LuaHandle luastate1{lua_newstate(...)};
// after this lua_close for luastate1's orinigal native handle will not called
// it contains new state, moved object contains null
luastate1 = LuaHandle{lua_newstate(.. .)};
```

My fix is just to swap handles without overwite, destructor of moved object correctly close handle. Other changes are not related with mem leak.

Explicit constructor is just syntax hint to avoid pitfalls when you can accidentally capture and destroy handle. For example:
```cpp
void foo(LuaHandle);
void bar(lua_State*);
lua_State* a = ...
foo(a);
bar(a); // error! a handle is released
```


`if this == &rhs` is just check for code like `luahandle a; a = std::move(a)` it can be freely omitted at all, because at the moment lua handle does not contain any complex logic and this example looks synthetic and buggy, check is not required. If you have additional questions or examples feel free to ask